### PR TITLE
Fix sonic-db-cli dictionary output format not backward compatible issue.

### DIFF
--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -477,12 +477,12 @@ string RedisReply::formatTupleReply(struct redisReply **element, size_t elements
 
 string RedisReply::formatStringWithQuot(string str)
 {
-    if (valuestr.find('\'') != std::string::npos)
+    if (str.find('\'') != std::string::npos)
     {
-        return "\"" + valuestr + "\"";
+        return "\"" + str + "\"";
     }
     
-    return "'" + valuestr + "'";
+    return "'" + str + "'";
 }
 
 }

--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -475,7 +475,7 @@ string RedisReply::formatTupleReply(struct redisReply **element, size_t elements
     return swss::join(", ", '(', ')', elementvector.begin(), elementvector.end());
 }
 
-string RedisReply::formatStringWithQuot(string& str)
+string RedisReply::formatStringWithQuot(string str)
 {
     if (valuestr.find('\'') != std::string::npos)
     {

--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -434,7 +434,9 @@ string RedisReply::formatDictReply(struct redisReply **element, size_t elements)
     vector<string> elementvector;
     for (unsigned int i = 0; i < elements; i += 2)
     {
-        elementvector.push_back("'" + to_string(element[i]) + "': '" + to_string(element[i+1]) + "'");
+        string key = formatStringWithQuot(to_string(element[i]));
+        string value = formatStringWithQuot(to_string(element[i + 1]));
+        elementvector.push_back(key + ": " + value);
     }
 
     return swss::join(", ", '{', '}', elementvector.begin(), elementvector.end());
@@ -445,7 +447,7 @@ string RedisReply::formatArrayReply(struct redisReply **element, size_t elements
     vector<string> elementvector;
     for (unsigned int i = 0; i < elements; i++)
     {
-        elementvector.push_back("'" + to_string(element[i]) + "'");
+        elementvector.push_back(formatStringWithQuot(to_string(element[i])));
     }
 
     return swss::join(", ", '[', ']', elementvector.begin(), elementvector.end());
@@ -467,10 +469,20 @@ string RedisReply::formatTupleReply(struct redisReply **element, size_t elements
     vector<string> elementvector;
     for (unsigned int i = 0; i < elements; i++)
     {
-        elementvector.push_back("'" + to_string(element[i]) + "'");
+        elementvector.push_back(formatStringWithQuot(to_string(element[i])));
     }
 
     return swss::join(", ", '(', ')', elementvector.begin(), elementvector.end());
+}
+
+string RedisReply::formatStringWithQuot(string& str)
+{
+    if (valuestr.find('\'') != std::string::npos)
+    {
+        return "\"" + valuestr + "\"";
+    }
+    
+    return "'" + valuestr + "'";
 }
 
 }

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -109,7 +109,7 @@ private:
     static std::string formatArrayReply(struct redisReply **element, size_t elements);
     static std::string formatListReply(struct redisReply **element, size_t elements);
     static std::string formatTupleReply(struct redisReply **element, size_t elements);
-    static std::string formatStringWithQuot(std::string& str);
+    static std::string formatStringWithQuot(std::string str);
 
     redisReply *m_reply;
 };

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -109,6 +109,7 @@ private:
     static std::string formatArrayReply(struct redisReply **element, size_t elements);
     static std::string formatListReply(struct redisReply **element, size_t elements);
     static std::string formatTupleReply(struct redisReply **element, size_t elements);
+    static std::string formatStringWithQuot(string& str);
 
     redisReply *m_reply;
 };

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -109,7 +109,7 @@ private:
     static std::string formatArrayReply(struct redisReply **element, size_t elements);
     static std::string formatListReply(struct redisReply **element, size_t elements);
     static std::string formatTupleReply(struct redisReply **element, size_t elements);
-    static std::string formatStringWithQuot(string& str);
+    static std::string formatStringWithQuot(std::string& str);
 
     redisReply *m_reply;
 };

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -130,6 +130,20 @@ TEST(sonic_db_cli, test_cli_hscan_commands)
     args[4] = "0";
     output = runCli(5, args);
     EXPECT_EQ("(0, {})\n", output);
+
+    // hset to test DB
+    args[2] = "HSET";
+    args[3] = "testkey";
+    args[4] = "testfield";
+    args[5] = "{'value': 'with qute'}";
+    output = runCli(6, args);
+    EXPECT_EQ("1\n", output);
+    
+    // hgetall from test db
+    args[2] = "HGETALL";
+    args[3] = "testkey";
+    output = runCli(4, args);
+    EXPECT_EQ("{'testfield': \"{'value': 'with qute'}\"}\n", output);
 }
 
 TEST(sonic_db_cli, test_cli_pop_commands)

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -137,8 +137,8 @@ TEST(sonic_db_cli, test_cli_hscan_commands)
     args[4] = "testfield";
     args[5] = "{'value': 'with qute'}";
     output = runCli(6, args);
-    EXPECT_EQ("1\n", output);
-    
+    EXPECT_EQ("0\n", output);
+
     // hgetall from test db
     args[2] = "HGETALL";
     args[3] = "testkey";


### PR DESCRIPTION
#### Why I did it
Fix sonic-db-cli dictionary output format not backward compatible issue: https://github.com/sonic-net/sonic-buildimage/issues/11945

#### How I did it
Improve redis reply format method, keep same format with redis-py.

#### How to verify it
Add c++ unit test to cover all code.
Pass all E2E test scenario.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix sonic-db-cli dictionary output format not backward compatible issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

