### PR TITLE
Modify azure pipeline to install libyang in azure pipeline steps.

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -160,6 +160,6 @@ jobs:
         targetFolder: $(Build.ArtifactStagingDirectory)
   - publish: $(Build.ArtifactStagingDirectory)/
     # publish artifact with retry count, otherwise "artifact already exist" error will block job re-run.
-    artifact: ${{ parameters.syslog_artifact_name }}_${System.JobAttempt}
+    artifact: ${{ parameters.syslog_artifact_name }}_$(System.JobAttempt)
     displayName: "Publish syslog artifacts"
     condition: always()

--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -20,6 +20,10 @@ parameters:
 - name: sonic_slave
   type: string
 
+- name: debian_version
+  type: string
+  default: buster
+
 - name: swss_common_artifact_name
   type: string
 
@@ -82,12 +86,31 @@ jobs:
       sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
       sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
       sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
+      sudo sed -ri 's/^databases .*/databases 17/' /etc/redis/redis.conf
       sudo service redis-server start
 
       sudo apt-get install -y rsyslog
       sudo service rsyslog start
 
     displayName: "Install dependencies"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib
+      patterns: |
+        target/debs/${{ parameters.debian_version }}/libyang-*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+    displayName: "Download libyang from common lib"
+  - script: |
+      set -ex
+      sudo dpkg -i $(find ./download -name *.deb)
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    displayName: "Install libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
@@ -136,6 +159,7 @@ jobs:
         contents: 'syslog-all.tgz'
         targetFolder: $(Build.ArtifactStagingDirectory)
   - publish: $(Build.ArtifactStagingDirectory)/
-    artifact: ${{ parameters.syslog_artifact_name }}
+    # publish artifact with retry count, otherwise "artifact already exist" error will block job re-run.
+    artifact: ${{ parameters.syslog_artifact_name }}_${System.JobAttempt}
     displayName: "Publish syslog artifacts"
     condition: always()

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -72,6 +72,9 @@ jobs:
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libswsscommon_1.0.0_*.deb
+        libswsscommon-dev_1.0.0*.deb
     displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -72,9 +72,6 @@ jobs:
     inputs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       path: $(Build.ArtifactStagingDirectory)/download
-      patterns: |
-        libswsscommon_1.0.0_*.deb
-        libswsscommon-dev_1.0.0*.deb
     displayName: "Download pre-stage built ${{ parameters.swss_common_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -103,6 +100,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-genl*.deb
         target/debs/${{ parameters.debian_version }}/libnl-route*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_*.deb
     displayName: "Download common libs"
 
   - script: |
@@ -110,7 +109,7 @@ jobs:
       sudo dpkg -i $(find ./download -name *.deb)
       rm -rf download || true
     workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install libnl3, sonic swss common, and sairedis"
+    displayName: "Install libnl3, libyang, sonic swss common, and sairedis"
   - script: |
       set -ex
       rm ../*.deb || true

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -134,7 +134,6 @@ jobs:
         sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
         sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
         sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
-        sudo sed -ri 's/^databases .*/databases 17/' /etc/redis/redis.conf
         sudo service redis-server restart
         sudo mkdir /usr/local/yang-models
 

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -67,6 +67,47 @@ jobs:
         libnl-nf-3-dev \
         swig
     displayName: "Install dependencies"
+  - task: DownloadPipelineArtifact@2
+    # amd64 artifact name does not has arch suffix
+    condition: eq('${{ parameters.arch }}', 'amd64')
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib
+      patterns: |
+        target/debs/${{ parameters.debian_version }}/libyang-*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+    displayName: "Download libyang from amd64 common lib"
+  - task: DownloadPipelineArtifact@2
+    condition: ne('${{ parameters.arch }}', 'amd64')
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib.${{ parameters.arch }}
+      patterns: |
+        target/debs/${{ parameters.debian_version }}/libyang-*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+    displayName: "Download libyang from common lib"
+  - script: |
+      set -ex
+      sudo dpkg -i $(find ./download -name *.deb)
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: ne('${{ parameters.debian_version }}', 'bullseye')
+    displayName: "Install libyang from common lib"
+    # Azure.sonic-buildimage.common_libs does not build libs for bullseye, so install libyang-dev by apt-get
+  - script: |
+      sudo apt-get install -qq -y \
+        libyang-dev
+    condition: eq('${{ parameters.debian_version }}', 'bullseye')
+    displayName: "Install libyang for bullseye"
   - script: |
       set -ex
       rm ../*.deb || true
@@ -93,7 +134,9 @@ jobs:
         sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf
         sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf
         sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
+        sudo sed -ri 's/^databases .*/databases 17/' /etc/redis/redis.conf
         sudo service redis-server restart
+        sudo mkdir /usr/local/yang-models
 
         sudo dpkg -i libswsscommon_*.deb
         sudo dpkg -i python-swsscommon_*.deb
@@ -103,6 +146,8 @@ jobs:
         pytest --cov=. --cov-report=xml
         mv coverage.xml tests/coverage.xml
         gcovr -r ./ -e ".*/swsscommon_wrap.cpp" --exclude-unreachable-branches --exclude-throw-branches -x --xml-pretty  -o coverage.xml
+
+        rm -rf $(Build.ArtifactStagingDirectory)/download
       displayName: "Run swss common unit tests"
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: ${{ parameters.artifact_name }}

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -41,7 +41,7 @@ jobs:
       ls -l
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
-      sudo apt-get install -y libhiredis0.14
+      sudo apt-get install -y libhiredis0.14 libyang0.16
       sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 

--- a/BUILD
+++ b/BUILD
@@ -15,7 +15,7 @@ cc_library(
     includes = [
         "common",
     ],
-    linkopts = ["-lpthread -lhiredis -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 -lzmq -lboost_serialization -luuid"],
+    linkopts = ["-lpthread -lhiredis -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 -lzmq -lboost_serialization -luuid -lyang"],
     visibility = ["//visibility:public"],
 )
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ stages:
         sudo apt-get install -y python3-pip
         sudo pip3 install pytest
         sudo apt-get install -y python
-        sudo apt-get install cmake libgtest-dev libgmock-dev
+        sudo apt-get install cmake libgtest-dev libgmock-dev libyang-dev
         cd /usr/src/gtest && sudo cmake . && sudo make
         ARCH=$(dpkg --print-architecture)
         set -x
@@ -95,6 +95,7 @@ stages:
       artifact_name: sonic-swss-common
       run_unit_test: true
       archive_gcov: true
+      debian_version: ${{ parameters.debian_version }}
 
 - stage: BuildArm
   dependsOn: Build
@@ -107,6 +108,7 @@ stages:
       pool: sonicbld-armhf
       sonic_slave: sonic-slave-${{ parameters.debian_version }}-armhf
       artifact_name: sonic-swss-common.armhf
+      debian_version: ${{ parameters.debian_version }}
 
   - template: .azure-pipelines/build-template.yml
     parameters:
@@ -115,6 +117,7 @@ stages:
       pool: sonicbld-arm64
       sonic_slave: sonic-slave-${{ parameters.debian_version }}-arm64
       artifact_name: sonic-swss-common.arm64
+      debian_version: ${{ parameters.debian_version }}
 
 - stage: BuildBullseye
   dependsOn: Build
@@ -139,6 +142,7 @@ stages:
       swss_common_artifact_name: sonic-swss-common
       artifact_name: sonic-sairedis
       syslog_artifact_name: sonic-sairedis.syslog
+      debian_version: ${{ parameters.debian_version }}
 
 - stage: BuildSwss
   dependsOn: BuildSairedis


### PR DESCRIPTION
#### Why I did it
Support sonic-swss-common build and link with libyang for read Yang model defaut value.

#### How I did it
Modify azure pipeline to install libyang in azure pipeline steps.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Modify azure pipeline to install libyang in azure pipeline steps.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

