### PR TITLE
Add decorator for Yang default value and profile config.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -38,6 +38,7 @@ libswsscommon_la_SOURCES = \
     dbinterface.cpp           \
     sonicv2connector.cpp      \
     table.cpp                 \
+    decoratortable.cpp        \
     json.cpp                  \
     producertable.cpp         \
     producerstatetable.cpp    \
@@ -66,6 +67,7 @@ libswsscommon_la_SOURCES = \
     exec.cpp                  \
     saiaclschema.cpp          \
     subscriberstatetable.cpp  \
+    decoratorsubscriberstatetable.cpp \
     timestamp.cpp             \
     warm_restart.cpp          \
     luatable.cpp              \

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -240,6 +240,133 @@ protected:
                     entry = self.raw_to_typed(entry)
                     ret.setdefault(table_name, {})[self.deserialize_key(row)] = entry
             return ret
+
+    def YangDefaultDecorator(config_db_connector):
+        # backup decorated methods
+        config_db_connector.ori_get_entry = config_db_connector.get_entry
+        config_db_connector.ori_get_table = config_db_connector.get_table
+        config_db_connector.ori_get_config = config_db_connector.get_config
+        config_db_connector.ori_set_entry = config_db_connector.set_entry
+        config_db_connector.ori_mod_entry = config_db_connector.mod_entry
+        config_db_connector.ori_delete_table = config_db_connector.delete_table
+        config_db_connector.ori_mod_config = config_db_connector.mod_config
+        # helper methods for append profile and default values to result.
+        def _append_profile(result):
+            client = config_db_connector.get_redis_client(config_db_connector.db_name)
+            profile_config = ProfileProvider.instance().getConfigs(client)
+            for table_name in profile_config:
+                profile_table = profile_config[table_name]
+                if table_name not in result:
+                    result[table_name] = profile_table
+                else:
+                    config_table = result[table_name]
+                    for profile_key in profile_table:
+                        if profile_key not in config_table:
+                            config_table[profile_key] = profile_table[profile_key]
+        def _append_profile_table(table, result):
+            client = config_db_connector.get_redis_client(config_db_connector.db_name)
+            profile_keys = ProfileProvider.instance().getKeys(table, client)
+            for profile_key in profile_keys:
+                if profile_key not in result:
+                    serialized_key = config_db_connector.serialize_key(profile_key)
+                    result[profile_key] = ProfileProvider.instance().getConfigs(table, serialized_key, client)
+        def _get_profile(table, key):
+            serialized_key = config_db_connector.serialize_key(key)
+            client = config_db_connector.get_redis_client(config_db_connector.db_name)
+            return ProfileProvider.instance().getConfigs(table, serialized_key, client)
+        def _append_default_value(table, key, data):
+            if data is None or len(data) == 0:
+                # empty entry means the entry been deleted
+                return data
+            serialized_key = config_db_connector.serialize_key(key)
+            defaultValues = DefaultValueProvider.instance().getDefaultValues(table, serialized_key)
+            for field in defaultValues:
+                if field not in data:
+                    data[field] = defaultValues[field]
+        def _try_delete_or_revert_profile(table, key, data):
+            serialized_key = config_db_connector.serialize_key(key)
+            client = config_db_connector.get_redis_client(config_db_connector.db_name)
+            if data is None or len(data) == 0:
+                # set a entry to empty will delete this entry
+                ProfileProvider.instance().tryDeleteItem(table, serialized_key, client)
+            else:
+                ProfileProvider.instance().tryRevertItem(table, serialized_key, client)
+        def _try_delete_profile_table(table):
+            client = config_db_connector.get_redis_client(config_db_connector.db_name)
+            keys = ProfileProvider.instance().getKeys(table, client)
+            for key in keys:
+                serialized_key = config_db_connector.serialize_key(key)
+                ProfileProvider.instance().tryDeleteItem(table, serialized_key, client)
+        def _try_delete_profile(config):
+            # the implementation of this method highly related with original mod_config behavior:
+            # 1. any table does not exist in config will not be changed.
+            # 2. any key remove from table will be deleted.
+            # 3. any key exist in table will be updated: if set data of that key to {}, the key also will be deleted.
+            client = config_db_connector.get_redis_client(config_db_connector.db_name)
+            profile_config = ProfileProvider.instance().getConfigs(client)
+            # delete/revert key in modified config tables, according to (1) not handle not existed tables
+            for tablename in config:
+                table = config[tablename]
+                if tablename not in profile_config:
+                    continue
+
+                profile_table = profile_config[tablename]
+                # delete removed key according to (2)
+                for key in profile_table:
+                    if key not in table:
+                        serialized_key = config_db_connector.serialize_key(key)
+                        ProfileProvider.instance().tryDeleteItem(tablename, serialized_key, client)
+                # try delete/revert still existed key according to (3)
+                for key in table:
+                    _try_delete_or_revert_profile(tablename, key, table[key])
+        # override read APIs
+        def get_entry(table, key):
+            result = config_db_connector.ori_get_entry(table, key)
+            if result is None or len(result) == 0:
+                # when there are any user config, profile will be overwrite.
+                result = _get_profile(table, key)
+            _append_default_value(table, key, result)
+            return result
+        def get_table(table):
+            result = config_db_connector.ori_get_table(table)
+            _append_profile_table(table, result)
+            for key in result:
+                _append_default_value(table, key, result[key])
+            return result
+        def get_config():
+            result = config_db_connector.ori_get_config()
+            _append_profile(result)
+            for table in result:
+                for key in result[table]:
+                    # Can not pass result[table][key] as parameter here, because python will create a copy. re-assign entry to result to bypass this issue.
+                    entry = result[table][key]
+                    _append_default_value(table, key, entry)
+                    result[table][key] = entry
+            return result
+        # override write and delete APIs
+        def set_entry(table, key, data):
+            # set a entry to empty will delete this entry
+            _try_delete_or_revert_profile(table, key, data)
+            return config_db_connector.ori_set_entry(table, key, data)
+        def mod_entry(table, key, data):
+            _try_delete_or_revert_profile(table, key, data)
+            return config_db_connector.ori_mod_entry(table, key, data)
+        def delete_table(table):
+            _try_delete_profile_table(table)
+            return config_db_connector.ori_delete_table(table)
+        def mod_config(config):
+            _try_delete_profile(config)
+            return config_db_connector.ori_mod_config(config)
+        # set decorate methods
+        config_db_connector.get_entry = get_entry
+        config_db_connector.get_table = get_table
+        config_db_connector.get_config = get_config
+        config_db_connector.set_entry = set_entry
+        config_db_connector.mod_entry = mod_entry
+        config_db_connector.delete_table = delete_table
+        config_db_connector.mod_config = mod_config
+        return config_db_connector
+
 %}
 #endif
 

--- a/common/decoratorsubscriberstatetable.cpp
+++ b/common/decoratorsubscriberstatetable.cpp
@@ -1,0 +1,73 @@
+#include <boost/algorithm/string.hpp>
+#include "common/decoratorsubscriberstatetable.h"
+#include "common/defaultvalueprovider.h"
+#include "common/profileprovider.h"
+
+using namespace std;
+using namespace swss;
+
+DecoratorSubscriberStateTable::DecoratorSubscriberStateTable(DBConnector *db, const string &tableName, int popBatchSize, int pri)
+:SubscriberStateTable(db, tableName, popBatchSize, pri)
+{
+    // Subscribe PROFILE_DELETE table for profile delete event
+    m_profile_keyspace = "__keyspace@";
+    m_profile_keyprefix = ProfileProvider::instance().getDeletedKeyName(tableName, "", db);
+    m_profile_keyspace += to_string(db->getDbId()) + "__:" + m_profile_keyprefix + "*";
+
+    m_subscribe->psubscribe(m_profile_keyspace);
+}
+
+/* Get multiple pop elements */
+void DecoratorSubscriberStateTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const string &prefix)
+{
+    SubscriberStateTable::pops(vkco, prefix);
+    for (auto& kco : vkco)
+    {
+        appendDefaultValue(kfvKey(kco), kfvOp(kco), kfvFieldsValues(kco));
+    }
+}
+
+
+void DecoratorSubscriberStateTable::appendDefaultValue(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs)
+{
+    if (op != SET_COMMAND)
+    {
+        return;
+    }
+
+    // Not append profile config, because 'SET' command will overwrite profile config.
+    auto table = getTableName();
+    DefaultValueProvider::instance().appendDefaultValues(table, key, fvs);
+}
+
+void DecoratorSubscriberStateTable::onPopUnknownPattern(RedisMessage& message, deque<KeyOpFieldsValuesTuple> &vkco)
+{
+    if (message.pattern != m_profile_keyspace)
+    {
+        SWSS_LOG_ERROR("invalid pattern %s returned for pmessage of %s", message.pattern.c_str(), m_profile_keyspace.c_str());
+        SubscriberStateTable::onPopUnknownPattern(message, vkco);
+        return;
+    }
+
+    string op = message.data;
+    if ("del" == op)
+    {
+        // 'DEL' from PROFILE_DETETE table will revert profile config, ignore this event because there will always be a user config 'SET' event after this event.
+        return;
+    }
+
+    string msg = message.channel;
+    size_t pos = msg.find(m_profile_keyprefix);
+    if (pos == msg.npos)
+    {
+        SWSS_LOG_ERROR("invalid key returned for pmessage of %s", m_profile_keyspace.c_str());
+        return;
+    }
+
+    // 'SET' to PROFILE_DETETE table is delete profile config, convert this event to a config 'DEL' event
+    string key = msg.substr(pos + m_profile_keyprefix.length());
+    KeyOpFieldsValuesTuple kco;
+    kfvKey(kco) = key;
+    kfvOp(kco) = DEL_COMMAND;
+    vkco.push_back(kco);
+}

--- a/common/decoratorsubscriberstatetable.h
+++ b/common/decoratorsubscriberstatetable.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <assert.h>
+#include <string>
+#include <queue>
+#include <tuple>
+#include <utility>
+#include <map>
+#include <memory>
+#include <deque>
+#include "table.h"
+#include "subscriberstatetable.h"
+
+namespace swss {
+
+class DecoratorSubscriberStateTable : public SubscriberStateTable 
+{
+public:
+    DecoratorSubscriberStateTable(DBConnector *db, const std::string &tableName, int popBatchSize = swss::TableConsumable::DEFAULT_POP_BATCH_SIZE, int pri = 0);
+
+    /* Get all elements available */
+    void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX) override;
+
+private:
+    std::string m_profile_keyspace;
+
+    std::string m_profile_keyprefix;
+
+    /* Handle SubscriberStateTable unknown pattern */
+    void onPopUnknownPattern(RedisMessage& message, std::deque<KeyOpFieldsValuesTuple> &vkco) override;
+
+    void appendDefaultValue(std::string &key, std::string &op, std::vector<FieldValueTuple> &fvs);
+};
+
+}

--- a/common/decoratortable.cpp
+++ b/common/decoratortable.cpp
@@ -1,0 +1,150 @@
+#include <boost/algorithm/string.hpp>
+
+#include "common/decoratortable.h"
+#include "common/defaultvalueprovider.h"
+#include "common/profileprovider.h"
+
+using namespace std;
+using namespace swss;
+
+DecoratorTable::DecoratorTable(const DBConnector *db, const string &tableName)
+    : Table(db, tableName)
+{
+}
+
+DecoratorTable::DecoratorTable(RedisPipeline *pipeline, const string &tableName, bool buffered)
+:Table(pipeline, tableName, buffered)
+{
+}
+
+DecoratorTable::~DecoratorTable()
+{
+}
+
+/* Get all the field-value tuple of the table entry with the key */
+bool DecoratorTable::get(const string &key, vector<pair<string, string>> &ovalues)
+{
+    bool result = Table::get(key, ovalues);
+    auto connector = const_cast<DBConnector*>(m_pipe->getDBConnector());
+    auto table = getTableName();
+
+    // Append profile config
+    bool append = ProfileProvider::instance().appendConfigs(table, key, ovalues, connector);
+    if (!result && append)
+    {
+        // No user config on this key, but found profile config on this key.
+        result = true;
+    }
+
+    // Append default values
+    DefaultValueProvider::instance().appendDefaultValues(table, key, ovalues);
+
+    return result;
+}
+
+bool DecoratorTable::hget(const string &key, const string &field,  string &value)
+{
+    auto result = Table::hget(key,
+                        field,
+                        value);
+    if (result)
+    {
+        return true;
+    }
+
+    auto connector = const_cast<DBConnector*>(m_pipe->getDBConnector());
+    auto table = getTableName();
+
+    // Try append profile config
+    auto profile = ProfileProvider::instance().getConfig(table, key, field, connector);
+    if (profile != nullptr)
+    {
+        value = *profile;
+        return true;
+    }
+
+    // Try append default values
+    auto default_value = DefaultValueProvider::instance().getDefaultValue(table, key, field);
+    if (default_value != nullptr)
+    {
+        value = *default_value;
+        return true;
+    }
+
+    return false;
+}
+
+/* Get all the keys in the table */
+void DecoratorTable::getKeys(vector<string> &keys)
+{
+    Table::getKeys(keys);
+
+    // Append profile keys
+    auto connector = const_cast<DBConnector*>(m_pipe->getDBConnector());
+    auto table = getTableName();
+    auto profile_keys = ProfileProvider::instance().getKeys(table, connector);
+    for (auto &profile_key : profile_keys)
+    {
+        if(find(keys.begin(), keys.end(), profile_key) == keys.end())
+        {
+            keys.emplace_back(profile_key);
+        }
+    }
+}
+
+/* Set an entry in the DB directly and configure ttl for it (op not in use) */
+void DecoratorTable::set(const std::string &key,
+                 const std::vector<FieldValueTuple> &values, 
+                 const std::string &op,
+                 const std::string &prefix,
+                 const int64_t &ttl)
+{
+    auto connector = const_cast<DBConnector*>(m_pipe->getDBConnector());
+    auto table = getTableName();
+    if (values.size())
+    {
+        ProfileProvider::instance().tryRevertItem(table, key, connector);
+    }
+    else
+    {
+        // Set a entry to empty will delete entry.
+        ProfileProvider::instance().tryDeleteItem(table, key, connector);
+    }
+
+    Table::set(key,
+                 values, 
+                 op,
+                 prefix,
+                 ttl);
+}
+
+/* Delete an entry in the table */
+void DecoratorTable::del(const std::string &key,
+                 const std::string &op,
+                 const std::string &prefix)
+{
+    auto connector = const_cast<DBConnector*>(m_pipe->getDBConnector());
+    auto table = getTableName();
+    ProfileProvider::instance().tryDeleteItem(table, key, connector);
+
+    Table::del(key,
+                 op,
+                 prefix);
+}
+
+void DecoratorTable::hset(const std::string &key,
+                 const std::string &field,
+                 const std::string &value,
+                 const std::string &op,
+                 const std::string &prefix)
+{
+    auto connector = const_cast<DBConnector*>(m_pipe->getDBConnector());
+    auto table = getTableName();
+    ProfileProvider::instance().tryRevertItem(table, key, connector);
+
+    Table::hset(key,
+                 field,
+                 value,
+                 op,
+                 prefix);
+}

--- a/common/decoratortable.h
+++ b/common/decoratortable.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <assert.h>
+#include <string>
+#include <queue>
+#include <tuple>
+#include <utility>
+#include <map>
+#include <memory>
+#include <deque>
+#include "table.h"
+#include "subscriberstatetable.h"
+
+namespace swss {
+
+class DecoratorTable : public Table  
+{
+public:
+    DecoratorTable(const DBConnector *db, const std::string &tableName);
+    DecoratorTable(RedisPipeline *pipeline, const std::string &tableName, bool buffered);
+    ~DecoratorTable() override;
+
+    /* Get all the field-value tuple of the table entry with the key */
+    bool get(const std::string &key, std::vector<std::pair<std::string, std::string>> &ovalues) override;
+
+    /* Get an entry field-value from the table */
+    bool hget(const std::string &key, const std::string &field,  std::string &value) override;
+
+    /* Get all the keys from the table */
+    void getKeys(std::vector<std::string> &keys) override;
+
+    /* Set an entry in the DB directly and configure ttl for it (op not in use) */
+    void set(const std::string &key,
+                     const std::vector<FieldValueTuple> &values, 
+                     const std::string &op,
+                     const std::string &prefix,
+                     const int64_t &ttl) override;
+
+    /* Delete an entry in the table */
+    void del(const std::string &key,
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX) override;
+
+    /* Set an entry field in the table */
+    void hset(const std::string &key,
+                     const std::string &field,
+                     const std::string &value,
+                     const std::string &op = "",
+                     const std::string &prefix = EMPTY_PREFIX) override;
+};
+
+}

--- a/common/subscriberstatetable.cpp
+++ b/common/subscriberstatetable.cpp
@@ -118,7 +118,8 @@ void SubscriberStateTable::pops(deque<KeyOpFieldsValuesTuple> &vkco, const strin
         auto ctx = event->getContext()->element[1];
         if (message.pattern != m_keyspace)
         {
-            SWSS_LOG_ERROR("invalid pattern %s returned for pmessage of %s", message.pattern.c_str(), m_keyspace.c_str());
+            // Inherited class may subscribe more pattern and handle their pattern by override  onPopUnknownPattern method.
+            onPopUnknownPattern(message, vkco);
             continue;
         }
 
@@ -175,6 +176,11 @@ shared_ptr<RedisReply> SubscriberStateTable::popEventBuffer()
     m_keyspace_event_buffer.pop_front();
 
     return reply;
+}
+
+void SubscriberStateTable::onPopUnknownPattern(RedisMessage& message, deque<KeyOpFieldsValuesTuple> &vkco)
+{
+    SWSS_LOG_ERROR("invalid pattern %s returned for pmessage of %s", message.pattern.c_str(), m_keyspace.c_str());
 }
 
 }

--- a/common/subscriberstatetable.h
+++ b/common/subscriberstatetable.h
@@ -25,6 +25,9 @@ public:
         return !m_buffer.empty();
     }
 
+protected:
+    virtual void onPopUnknownPattern(RedisMessage& message, std::deque<KeyOpFieldsValuesTuple> &vkco);
+
 private:
     /* Pop keyspace event from event buffer. Caller should free resources. */
     std::shared_ptr<RedisReply> popEventBuffer();

--- a/common/table.h
+++ b/common/table.h
@@ -168,6 +168,8 @@ public:
     /* Get all the field-value tuple of the table entry with the key */
     virtual bool get(const std::string &key, std::vector<FieldValueTuple> &values) = 0;
 
+    virtual bool hget(const std::string &key, const std::string &field,  std::string &value) = 0;
+
     /* get all the keys in the table */
     virtual void getKeys(std::vector<std::string> &keys) = 0;
 

--- a/tests/test_decorator_ut.py
+++ b/tests/test_decorator_ut.py
@@ -1,0 +1,411 @@
+import os
+import pytest
+from swsscommon import swsscommon
+
+@pytest.fixture
+def prepare_yang_module():
+    # copy yang module
+    yang_file_name = "sonic-interface.yang"
+    yang_module_path = "/usr/local/yang-models"
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    yang_module_src = os.path.join(test_dir, "yang", yang_file_name)
+    yang_module_dest = os.path.join(yang_module_path, yang_file_name)
+    os.system("sudo mkdir {}".format(yang_module_path))
+    os.system("sudo cp {} {}".format(yang_module_src, yang_module_dest))
+
+    yield
+
+    # cleanup yang module
+    os.system("sudo rm -rf {}".format(yang_module_path))
+
+@pytest.fixture
+def reset_database():
+    os.system("redis-cli FLUSHALL")
+
+    yield
+
+    os.system("redis-cli FLUSHALL")
+
+def check_read_api_result(decorator, table, key, field, expected):
+    entry = decorator.get_entry(table, key)
+    assert entry[field] == expected
+
+    table_data = decorator.get_table(table)
+    assert table_data[key][field] == expected
+
+    config = decorator.get_config()
+    assert config[table][key][field] == expected
+
+def check_item_deleted(decorator, table, key):
+    entry = decorator.get_entry(table, key)
+    assert len(entry) == 0
+
+    table_data = decorator.get_table(table)
+    assert key not in table_data
+
+    config = decorator.get_config()
+    assert key not in config[table]
+
+def check_table_read_api_result(table, key, fieldname, expected):
+    # check get
+    result, fields = table.get(key)
+    assert result
+    field_exist = False
+    for field in fields:
+        if field[0] == fieldname:
+            field_exist = True
+            assert field[1] == expected
+    assert field_exist
+    
+    # check hget
+    result, value = table.hget(key, fieldname)
+    assert result
+    assert value == expected
+    
+    # check getKeys
+    keys = table.getKeys()
+    assert key in keys
+
+def test_decorator_read_yang_default_value(prepare_yang_module, reset_database):
+    """
+    Test YangDefaultDecorator read correct default values from Yang model.
+    """
+    conn = swsscommon.ConfigDBConnector()
+    decorator = swsscommon.YangDefaultDecorator(conn)
+    decorator.connect(wait_for_init=False)
+
+    # set to table without default value
+    table = "INTERFACE"
+    key = "TEST_INTERFACE"
+    data = { "test_field": "test_value" }
+    field = "nat_zone"
+    decorator.set_entry(table, key, data)
+
+    # check read API
+    check_read_api_result(decorator, table, key, field, "0")
+
+    # test set_entry
+    data[field] = '1'
+    decorator.set_entry(table, key, data)
+
+    # check read API
+    check_read_api_result(decorator, table, key, field, "1")
+
+    # test mod_entry
+    data[field] = '2'
+    decorator.mod_entry(table, key, data)
+
+    # check read API
+    check_read_api_result(decorator, table, key, field, "2")
+
+    # test mod_config
+    config = decorator.get_config()
+    config[table][key][field] = "3"
+    decorator.mod_config(config)
+
+    # check read API
+    check_read_api_result(decorator, table, key, field, "3")
+
+def test_decorator_read_profile_config(prepare_yang_module, reset_database):
+    """
+    Test YangDefaultDecorator read correct profile.
+    """
+    conn = swsscommon.ConfigDBConnector()
+    decorator = swsscommon.YangDefaultDecorator(conn)
+    decorator.connect(wait_for_init=False)
+
+    # setup profile config
+    profile_conn = swsscommon.ConfigDBConnector()
+    profile_conn.db_connect("PROFILE_DB")
+    table = "INTERFACE"
+    key = "TEST_INTERFACE"
+    profile_field = "profile"
+    profile_value = "value"
+    profile = { profile_field: profile_value }
+    profile_conn.set_entry(table, key, profile)
+
+    # check read API
+    field = "nat_zone"
+    check_read_api_result(decorator, table, key, field, "0")
+    check_read_api_result(decorator, table, key, profile_field, profile_value)
+    
+    # check default value overwrite by profile
+    profile_nat_zone = "1"
+    profile = { field: profile_nat_zone }
+    profile_conn.set_entry(table, key, profile)
+
+    check_read_api_result(decorator, table, key, field, profile_nat_zone)
+
+def test_decorator_delete_profile_config(prepare_yang_module, reset_database):
+    """
+    Test YangDefaultDecorator delete profile.
+    """
+    conn = swsscommon.ConfigDBConnector()
+    decorator = swsscommon.YangDefaultDecorator(conn)
+    decorator.connect(wait_for_init=False)
+
+    # setup profile config
+    profile_conn = swsscommon.ConfigDBConnector()
+    profile_conn.db_connect("PROFILE_DB")
+    table = "INTERFACE"
+    key = "TEST_INTERFACE"
+    profile_field = "profile"
+    profile_value = "value"
+    profile = { profile_field: profile_value }
+    profile_conn.set_entry(table, key, profile)
+    full_config = decorator.get_config()
+
+    # check delete profile by set_entry
+    decorator.set_entry(table, key, None)
+    
+    # profile been deleted from result
+    check_item_deleted(decorator, table, key)
+    
+    # revert deleted profile
+    decorator.set_entry(table, key, profile)
+
+    # profile avaliable again
+    check_read_api_result(decorator, table, key, profile_field, profile_value)
+
+    # check delete profile by mod_entry
+    decorator.mod_entry(table, key, None)
+    
+    # profile been deleted from result
+    check_item_deleted(decorator, table, key)
+    
+    # revert deleted profile
+    decorator.set_entry(table, key, profile)
+
+    # profile avaliable again
+    check_read_api_result(decorator, table, key, profile_field, profile_value)
+
+    # check delete profile by remove key with mod_config
+    full_config = decorator.get_config()
+    full_config[table].pop(key)
+    decorator.mod_config(full_config)
+    
+    # profile been deleted from result
+    check_item_deleted(decorator, table, key)
+    
+    # revert deleted profile
+    decorator.set_entry(table, key, profile)
+
+    # profile avaliable again
+    check_read_api_result(decorator, table, key, profile_field, profile_value)
+
+    # check delete profile by delete_table
+    decorator.delete_table(table)
+    
+    # profile been deleted from result
+    check_item_deleted(decorator, table, key)
+    
+    # revert deleted profile
+    decorator.set_entry(table, key, profile)
+
+    # profile avaliable again
+    check_read_api_result(decorator, table, key, profile_field, profile_value)
+
+    # check mod_config without table
+    full_config = decorator.get_config()
+    full_config.pop(table)
+    print(full_config)
+    decorator.mod_config(full_config)
+
+    # profile should not be deleted
+    check_read_api_result(decorator, table, key, profile_field, profile_value)
+
+def test_table_read_yang_default_value(prepare_yang_module, reset_database):
+    """
+    Test DecoratorTable read correct default values from Yang model.
+    """
+    # set to table without default value
+    conn = swsscommon.ConfigDBConnector()
+    decorator = swsscommon.YangDefaultDecorator(conn)
+    decorator.connect(wait_for_init=False)
+    table = "INTERFACE"
+    key = "TEST_INTERFACE"
+    data = { "test_field": "test_value" }
+    fieldname = "nat_zone"
+    decorator.set_entry(table, key, data)
+
+    # check read API
+    db = swsscommon.DBConnector("CONFIG_DB", 0)
+    table = swsscommon.DecoratorTable(db, 'INTERFACE')
+
+    # check read API
+    check_table_read_api_result(table, key, fieldname, "0")
+
+def test_table_read_profile_config(prepare_yang_module, reset_database):
+    """
+    Test DecoratorTable read correct profile config.
+    """
+    # setup profile config
+    profile_conn = swsscommon.ConfigDBConnector()
+    profile_conn.db_connect("PROFILE_DB")
+    tablename = "INTERFACE"
+    key = "TEST_INTERFACE"
+    profile_field = "profile"
+    profile_value = "value"
+    profile = { profile_field: profile_value }
+    profile_conn.set_entry(tablename, key, profile)
+
+    # check read API
+    db = swsscommon.DBConnector("CONFIG_DB", 0)
+    table = swsscommon.DecoratorTable(db, 'INTERFACE')
+
+    # check read API
+    yang_field_name = "nat_zone"
+    check_table_read_api_result(table, key, yang_field_name, "0")
+    check_table_read_api_result(table, key, profile_field, profile_value)
+    
+    # overwrite default value in profile
+    profile = { yang_field_name: "1" }
+    profile_conn.set_entry(tablename, key, profile)
+    check_table_read_api_result(table, key, yang_field_name, "1")
+
+def check_table_profile_deleted(table, key, fieldname):
+    # check get
+    result, fields = table.get(key)
+    assert result == False
+    
+    # check hget
+    result, value = table.hget(key, fieldname)
+    assert result == False
+    
+    # check getKeys
+    keys = table.getKeys()
+    assert len(keys) == 0
+
+def test_table_delete_profile_config(prepare_yang_module, reset_database):
+    """
+    Test DecoratorTable delete/revert profile config.
+    """
+    # setup profile config
+    profile_conn = swsscommon.ConfigDBConnector()
+    profile_conn.db_connect("PROFILE_DB")
+    tablename = "INTERFACE"
+    key = "TEST_INTERFACE"
+    profile_field = "profile"
+    profile_value = "value"
+    profile = { profile_field: profile_value }
+    profile_conn.set_entry(tablename, key, profile)
+
+    db = swsscommon.DBConnector("CONFIG_DB", 0)
+    table = swsscommon.DecoratorTable(db, 'INTERFACE')
+
+    # test delete profile by set()
+    fvs = swsscommon.FieldValuePairs([])
+    table.set(key, fvs, "", "", 100)
+    check_table_profile_deleted(table, key, profile_field)
+
+    # revert profile
+    fvs = swsscommon.FieldValuePairs([(profile_field, profile_value)])
+    table.set(key, fvs, "", "", 100)
+
+    # check read API
+    yang_field_name = "nat_zone"
+    check_table_read_api_result(table, key, yang_field_name, "0")
+    check_table_read_api_result(table, key, profile_field, profile_value)
+
+    # test delete profile by delete()
+    table.delete(key, "", "")
+    check_table_profile_deleted(table, key, profile_field)
+
+    # revert profile
+    fvs = swsscommon.FieldValuePairs([(profile_field, profile_value)])
+    table.set(key, fvs, "", "", 100)
+
+    # check read API
+    yang_field_name = "nat_zone"
+    check_table_read_api_result(table, key, yang_field_name, "0")
+    check_table_read_api_result(table, key, profile_field, profile_value)
+
+    # test revert by hset
+    table.delete(key, "", "")
+    check_table_profile_deleted(table, key, profile_field)
+
+    # revert by hset
+    table.hset(key, profile_field, profile_value, "", "")
+
+    # check read API
+    yang_field_name = "nat_zone"
+    check_table_read_api_result(table, key, yang_field_name, "0")
+    check_table_read_api_result(table, key, profile_field, profile_value)
+
+def test_DecoratorSubscriberStateTable():
+    """
+    Test DecoratorSubscriberStateTable can listen delete event.
+    """
+    # setup profile config
+    profile_conn = swsscommon.ConfigDBConnector()
+    profile_conn.db_connect("PROFILE_DB")
+    tablename = "INTERFACE"
+    profile_key = "TEST_INTERFACE"
+    profile_field = "profile"
+    profile_value = "value"
+    profile = { profile_field: profile_value }
+    profile_conn.set_entry(tablename, profile_key, profile)
+    
+    # setup select
+    db = swsscommon.DBConnector("CONFIG_DB", 0, True)
+    db.flushdb()
+    table = swsscommon.DecoratorTable(db, tablename)
+    sel = swsscommon.Select()
+    cst = swsscommon.DecoratorSubscriberStateTable(db, tablename)
+    sel.addSelectable(cst)
+
+    # delete profile by set empty value
+    fvs = swsscommon.FieldValuePairs([])
+    table.set(profile_key, fvs, "", "", 100)
+
+    # check select event
+    (state, c) = sel.select()
+    assert state == swsscommon.Select.OBJECT
+    (key, op, cfvs) = cst.pop()
+    assert key == profile_key
+    assert op == "DEL"
+    assert len(cfvs) == 0
+    
+    # revert deleted profile
+    fvs = swsscommon.FieldValuePairs([('a','b')])
+    table.set(profile_key, fvs, "", "", 100)
+
+    # check select event
+    (state, c) = sel.select()
+    assert state == swsscommon.Select.OBJECT
+
+    entries = swsscommon.transpose_pops(cst.pops())
+    entry_exist = False
+    for entry in entries:
+        (key, op, cfvs) = entry
+        if key == profile_key:
+            entry_exist = True
+            assert op == "SET"
+            assert len(cfvs) == 2
+            assert cfvs[0] == ('a', 'b')
+            assert cfvs[1] == ('nat_zone', '0')
+    assert entry_exist
+
+    # overwrite default value
+    fvs = swsscommon.FieldValuePairs([('a','b'), ('nat_zone','1')])
+    table.set(profile_key, fvs, "", "", 100)
+
+    # check select event
+    (state, c) = sel.select()
+    assert state == swsscommon.Select.OBJECT
+
+    print("start check")
+    entries = swsscommon.transpose_pops(cst.pops())
+    print(entries)
+    entry_exist = False
+    for entry in entries:
+        (key, op, cfvs) = entry
+        if key == profile_key:
+            entry_exist = True
+            assert op == "SET"
+            assert len(cfvs) == 2
+            assert cfvs[0] == ('a', 'b')
+            assert cfvs[1] == ('nat_zone', '1')
+    assert entry_exist
+    
+    


### PR DESCRIPTION
#### Why I did it
Support sonic-swss-common read Yang model defaut value.

#### How I did it
Add decorator for Yang default value and profile config.

#### How to verify it
Add new UT to cover new decorate code.
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add decorator for Yang default value and profile config.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

