### PR TITLE
[Inspur][swss-common][201911] Fix warm-reboot may cause orchagent is frozened and wait forever

### DIFF
--- a/common/warm_restart.cpp
+++ b/common/warm_restart.cpp
@@ -10,7 +10,8 @@ const WarmStart::WarmStartStateNameMap WarmStart::warmStartStateNameMap =
 {
     {INITIALIZED,   "initialized"},
     {RESTORED,      "restored"},
-    {RECONCILED,    "reconciled"}
+    {RECONCILED,    "reconciled"},
+    {WSDISABLED,    "disabled"}
 };
 
 const WarmStart::DataCheckStateNameMap WarmStart::dataCheckStateNameMap =

--- a/common/warm_restart.h
+++ b/common/warm_restart.h
@@ -17,6 +17,7 @@ public:
         INITIALIZED,
         RESTORED,
         RECONCILED,
+        WSDISABLED,
     };
 
     enum DataCheckState


### PR DESCRIPTION
[Inspur][swss-common][201911] Fix warm-reboot may cause orchagent is frozened and wait forever
    Description:
        1. When executing warm-reboot continuously, the orchagent cannot finish pre-warm task within 10 seconds.
        2. And then, the orchagent will be frozen by "second" warm restart.
        3. In order to prevent the orchagent is frozen, add warm start default status.
        4. If executing warm-reboot, will check orchagent wart start status.