### PR TITLE
[202205] fixing return code of swssloglevel script

### DIFF
--- a/common/loglevel.cpp
+++ b/common/loglevel.cpp
@@ -133,6 +133,10 @@ int main(int argc, char **argv)
         std::sort(keys.begin(), keys.end());
         for (const auto& key : keys)
         {
+            if(key == "JINJA2_CACHE")
+            {
+                continue;
+            }
             const auto redis_key = std::string(key).append(":").append(key);
             auto level = db.hget(redis_key, DAEMON_LOGLEVEL);
             if (nullptr == level)


### PR DESCRIPTION
bug-fix: when the user runs "swssloglevel -p" we get 1 return code.
In the previous implementation, we tried to get loglevel for the JINJA2 cache key and that led us to 1 return code.
I exclude the JINJA2 cache key to avoid this.