### PR TITLE
Check whether a pointer created by dynamic_cast is null before using it.

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -236,7 +236,10 @@ void Logger::settingThread()
         ConsumerStateTable *consumerStateTable = NULL;
         consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
         if (consumerStateTable == NULL)
-            continue;
+        {
+            SWSS_LOG_ERROR("dynamic_cast returns NULL.");
+            break;
+        }
         consumerStateTable->pop(koValues);
         std::string key = kfvKey(koValues), op = kfvOp(koValues);
 

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -1,5 +1,5 @@
 #include "logger.h"
-#include <assert.h>
+
 #include <algorithm>
 #include <stdarg.h>
 #include <stdio.h>
@@ -233,8 +233,10 @@ void Logger::settingThread()
         }
 
         KeyOpFieldsValuesTuple koValues;
-        ConsumerStateTable *consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
-        assert(consumerStateTable != NULL);
+        ConsumerStateTable *consumerStateTable = NULL;
+        consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
+        if (consumerStateTable == NULL)
+            continue;
         consumerStateTable->pop(koValues);
         std::string key = kfvKey(koValues), op = kfvOp(koValues);
 

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -237,7 +237,7 @@ void Logger::settingThread()
         consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
         if (consumerStateTable == NULL)
         {
-            SWSS_LOG_ERROR("dynamic_cast returns NULL.");
+            SWSS_LOG_ERROR("dynamic_cast returns NULL");
             break;
         }
         consumerStateTable->pop(koValues);

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -233,9 +233,7 @@ void Logger::settingThread()
         }
 
         KeyOpFieldsValuesTuple koValues;
-
-        ConsumerStateTable *consumerStateTable;
-        consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
+        ConsumerStateTable *consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
         if (consumerStateTable == NULL)
         {
             continue;

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -233,6 +233,7 @@ void Logger::settingThread()
         }
 
         KeyOpFieldsValuesTuple koValues;
+
         ConsumerStateTable *consumerStateTable;
         consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
         if (consumerStateTable == NULL)

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -1,5 +1,5 @@
 #include "logger.h"
-
+#include <assert.h>
 #include <algorithm>
 #include <stdarg.h>
 #include <stdio.h>
@@ -8,7 +8,6 @@
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
-#include <assert.h>
 #include "schema.h"
 #include "select.h"
 #include "dbconnector.h"

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -233,7 +233,7 @@ void Logger::settingThread()
         }
 
         KeyOpFieldsValuesTuple koValues;
-        ConsumerStateTable *consumerStateTable = NULL;
+        ConsumerStateTable *consumerStateTable;
         consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
         if (consumerStateTable == NULL)
         {

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -237,7 +237,7 @@ void Logger::settingThread()
         consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
         if (consumerStateTable == NULL)
         {
-            SWSS_LOG_ERROR("dynamic_cast returns NULL");
+            SWSS_LOG_ERROR("dynamic_cast returned NULL");
             break;
         }
         consumerStateTable->pop(koValues);

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -233,7 +233,8 @@ void Logger::settingThread()
         }
 
         KeyOpFieldsValuesTuple koValues;
-        ConsumerStateTable *consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
+        ConsumerStateTable *consumerStateTable = NULL;
+        consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
         if (consumerStateTable == NULL)
         {
             continue;

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
+#include <assert.h>
 #include "schema.h"
 #include "select.h"
 #include "dbconnector.h"
@@ -233,12 +234,8 @@ void Logger::settingThread()
         }
 
         KeyOpFieldsValuesTuple koValues;
-        ConsumerStateTable *consumerStateTable = NULL;
-        consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
-        if (consumerStateTable == NULL)
-        {
-            continue;
-        }
+        ConsumerStateTable *consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
+        assert(consumerStateTable != NULL);
         consumerStateTable->pop(koValues);
         std::string key = kfvKey(koValues), op = kfvOp(koValues);
 

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -233,7 +233,12 @@ void Logger::settingThread()
         }
 
         KeyOpFieldsValuesTuple koValues;
-        dynamic_cast<ConsumerStateTable *>(selectable)->pop(koValues);
+        ConsumerStateTable *consumerStateTable = dynamic_cast<ConsumerStateTable *>(selectable);
+        if (consumerStateTable == NULL)
+        {
+            continue;
+        }
+        consumerStateTable->pop(koValues);
         std::string key = kfvKey(koValues), op = kfvOp(koValues);
 
         if (op != SET_COMMAND || !m_settingChangeObservers.contains(key))


### PR DESCRIPTION
What I did
Check whether a pointer created by dynamic_cast is null before using it.
Why I did it
dynamic_cast<ConsumerStateTable *>(selectable) may return NULL
