### PR TITLE
[Fast/Warm restart] Implement helper class for waiting restart done

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -71,7 +71,8 @@ libswsscommon_la_SOURCES = \
     luatable.cpp              \
     countertable.cpp          \
     redisutility.cpp          \
-    restart_waiter.cpp
+    restart_waiter.cpp        \
+    redis_table_waiter.cpp
 
 libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS) $(CODE_COVERAGE_CXXFLAGS)
 libswsscommon_la_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CPPFLAGS) $(CODE_COVERAGE_CPPFLAGS)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -70,7 +70,8 @@ libswsscommon_la_SOURCES = \
     warm_restart.cpp          \
     luatable.cpp              \
     countertable.cpp          \
-    redisutility.cpp
+    redisutility.cpp          \
+    restart_waiter.cpp
 
 libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS) $(CODE_COVERAGE_CXXFLAGS)
 libswsscommon_la_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CPPFLAGS) $(CODE_COVERAGE_CPPFLAGS)

--- a/common/redis_table_waiter.cpp
+++ b/common/redis_table_waiter.cpp
@@ -1,0 +1,145 @@
+#include "redis_table_waiter.h"
+#include "select.h"
+#include "subscriberstatetable.h"
+
+using namespace swss;
+
+bool RedisTableWaiter::waitUntil(
+    DBConnector &db,
+    const std::string &tableName,
+    unsigned int maxWaitSec,
+    CheckFunc checkFunc)
+{
+    if (maxWaitSec == 0)
+    {
+        SWSS_LOG_ERROR("Error: invalid maxWaitSec value 0, must be larger than 0");
+        return false;
+    }
+
+    SubscriberStateTable table(&db, tableName);
+    Select s;
+    s.addSelectable(&table);
+
+    int maxWaitMs = static_cast<int>(maxWaitSec) * 1000;
+    int selectTimeout = maxWaitMs;
+    auto start = std::chrono::steady_clock::now();
+    while(1)
+    {
+        Selectable *sel = NULL;
+        int ret = s.select(&sel, selectTimeout, true);
+        if (ret == Select::OBJECT)
+        {
+            KeyOpFieldsValuesTuple kco;
+            table.pop(kco);
+            if (checkFunc(kco))
+            {
+                return true;
+            }
+        }
+        else if (ret == Select::ERROR)
+        {
+            SWSS_LOG_NOTICE("Error: wait redis table got error - %s!", strerror(errno));
+        }
+        else if (ret == Select::TIMEOUT)
+        {
+            SWSS_LOG_INFO("Timeout: wait redis table got select timeout");
+        }
+        else if (ret == Select::SIGNALINT)
+        {
+            return false;
+        }
+
+        auto end = std::chrono::steady_clock::now();
+        int delay = static_cast<int>(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
+
+        if (delay >= maxWaitMs)
+        {
+            return false;
+        }
+
+        selectTimeout = maxWaitMs - delay;
+    }
+
+    return false;
+}
+
+bool RedisTableWaiter::waitUntilFieldSet(
+    DBConnector &db,
+    const std::string &tableName,
+    const std::string &key,
+    const std::string &fieldName,
+    unsigned int maxWaitSec,
+    ConditionFunc cond)
+{
+    auto sep = SonicDBConfig::getSeparator(&db);
+    auto value = db.hget(tableName + sep + key, fieldName);
+    if (value && cond(*value.get()))
+    {
+        return true;
+    }
+
+    auto checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
+        if (SET_COMMAND == kfvOp(kco))
+        {
+            if (key == kfvKey(kco))
+            {
+                auto& values = kfvFieldsValues(kco);
+                for (auto& fvt: values)
+                {
+                    if (fieldName == fvField(fvt))
+                    {
+                        return cond(fvValue(fvt));
+                    }
+                }
+            }
+        }
+
+        return false;
+    };
+    return waitUntil(db, tableName, maxWaitSec, checkFunc);
+}
+
+bool RedisTableWaiter::waitUntilKeySet(
+    DBConnector &db,
+    const std::string &tableName,
+    const std::string &key,
+    unsigned int maxWaitSec)
+{
+    auto sep = SonicDBConfig::getSeparator(&db);
+    if (db.exists(tableName + sep + key))
+    {
+        return true;
+    }
+
+    auto checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
+        if (SET_COMMAND == kfvOp(kco))
+        {
+            return key == kfvKey(kco);
+        }
+        return false;
+    };
+    return waitUntil(db, tableName, maxWaitSec, checkFunc);
+}
+
+bool RedisTableWaiter::waitUntilKeyDel(
+    DBConnector &db,
+    const std::string &tableName,
+    const std::string &key,
+    unsigned int maxWaitSec)
+{
+    auto sep = SonicDBConfig::getSeparator(&db);
+    if (!db.exists(tableName + sep + key))
+    {
+        return true;
+    }
+
+    auto checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
+        if (DEL_COMMAND == kfvOp(kco))
+        {
+            return key == kfvKey(kco);
+        }
+        return false;
+    };
+    return waitUntil(db, tableName, maxWaitSec, checkFunc);
+}

--- a/common/redis_table_waiter.cpp
+++ b/common/redis_table_waiter.cpp
@@ -8,7 +8,7 @@ bool RedisTableWaiter::waitUntil(
     DBConnector &db,
     const std::string &tableName,
     unsigned int maxWaitSec,
-    CheckFunc checkFunc)
+    CheckFunc &checkFunc)
 {
     if (maxWaitSec == 0)
     {
@@ -70,7 +70,7 @@ bool RedisTableWaiter::waitUntilFieldSet(
     const std::string &key,
     const std::string &fieldName,
     unsigned int maxWaitSec,
-    ConditionFunc cond)
+    ConditionFunc &cond)
 {
     auto sep = SonicDBConfig::getSeparator(&db);
     auto value = db.hget(tableName + sep + key, fieldName);
@@ -79,7 +79,7 @@ bool RedisTableWaiter::waitUntilFieldSet(
         return true;
     }
 
-    auto checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
+    CheckFunc checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
         if (SET_COMMAND == kfvOp(kco))
         {
             if (key == kfvKey(kco))
@@ -112,7 +112,7 @@ bool RedisTableWaiter::waitUntilKeySet(
         return true;
     }
 
-    auto checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
+    CheckFunc checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
         if (SET_COMMAND == kfvOp(kco))
         {
             return key == kfvKey(kco);
@@ -134,7 +134,7 @@ bool RedisTableWaiter::waitUntilKeyDel(
         return true;
     }
 
-    auto checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
+    CheckFunc checkFunc = [&](const KeyOpFieldsValuesTuple &kco) -> bool {
         if (DEL_COMMAND == kfvOp(kco))
         {
             return key == kfvKey(kco);

--- a/common/redis_table_waiter.h
+++ b/common/redis_table_waiter.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "dbconnector.h"
+
+namespace swss
+{
+
+class RedisTableWaiter
+{
+public:
+    typedef std::function<bool(const std::string &)> ConditionFunc;
+    typedef std::function<bool(const KeyOpFieldsValuesTuple &)> CheckFunc;
+
+    static bool waitUntilFieldSet(DBConnector &db,
+                          const std::string &tableName,
+                          const std::string &key,
+                          const std::string &fieldName,
+                          unsigned int maxWaitSec,
+                          ConditionFunc cond);
+
+
+    static bool waitUntilKeySet(DBConnector &db,
+                          const std::string &tableName,
+                          const std::string &key,
+                          unsigned int maxWaitSec);
+
+    static bool waitUntilKeyDel(DBConnector &db,
+                          const std::string &tableName,
+                          const std::string &key,
+                          unsigned int maxWaitSec);
+
+    static bool waitUntil(
+        DBConnector &db,
+        const std::string &tableName,
+        unsigned int maxWaitSec,
+        CheckFunc checkFunc);
+
+};
+
+}

--- a/common/redis_table_waiter.h
+++ b/common/redis_table_waiter.h
@@ -19,7 +19,7 @@ public:
                           const std::string &key,
                           const std::string &fieldName,
                           unsigned int maxWaitSec,
-                          ConditionFunc cond);
+                          ConditionFunc &cond);
 
 
     static bool waitUntilKeySet(DBConnector &db,
@@ -36,7 +36,7 @@ public:
         DBConnector &db,
         const std::string &tableName,
         unsigned int maxWaitSec,
-        CheckFunc checkFunc);
+        CheckFunc &checkFunc);
 
 };
 

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -54,6 +54,12 @@ bool RestartWaiter::waitFastRestartDone(unsigned int maxWaitSec,
 bool RestartWaiter::doWait(DBConnector &stateDb,
                            unsigned int maxWaitSec)
 {
+    if (maxWaitSec == 0)
+    {
+        SWSS_LOG_ERROR("Error: invalid maxWaitSec value 0, must be larger than 0");
+        return false;
+    }
+
     int selectTimeout = static_cast<int>(maxWaitSec);
 
     SubscriberStateTable restartEnableTable(&stateDb, STATE_WARM_RESTART_ENABLE_TABLE_NAME);
@@ -110,7 +116,7 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
                     std::chrono::duration_cast<std::chrono::seconds>(end - start).count());
 
         selectTimeout -= delay;
-        if (selectTimeout < 0)
+        if (selectTimeout <= 0)
         {
             return false;
         }

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -60,7 +60,7 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
         return false;
     }
 
-    int selectTimeout = static_cast<int>(maxWaitSec);
+    int selectTimeout = static_cast<int>(maxWaitSec) * 1000;
 
     SubscriberStateTable restartEnableTable(&stateDb, STATE_WARM_RESTART_ENABLE_TABLE_NAME);
     Select s;
@@ -70,7 +70,7 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
     while (1)
     {
         Selectable *sel = NULL;
-        int ret = s.select(&sel, selectTimeout * 1000, true);
+        int ret = s.select(&sel, selectTimeout, true);
 
         if (ret == Select::OBJECT)
         {
@@ -113,7 +113,7 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
 
         auto end = std::chrono::steady_clock::now();
         int delay = static_cast<int>(
-                    std::chrono::duration_cast<std::chrono::seconds>(end - start).count());
+                    std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
 
         selectTimeout -= delay;
         if (selectTimeout <= 0)

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -20,7 +20,7 @@ bool RestartWaiter::waitAdvancedBootDone(
     bool isTcpConn)
 {
     DBConnector stateDb(STATE_DB_NAME, dbTimeout, isTcpConn);
-    return isWarmOrFastBootInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
+    return isAdvancedBootInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
 }
 
 bool RestartWaiter::waitWarmBootDone(
@@ -35,7 +35,7 @@ bool RestartWaiter::waitWarmBootDone(
         return true;
     }
 
-    return isWarmOrFastBootInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
+    return isAdvancedBootInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
 }
 
 bool RestartWaiter::waitFastBootDone(
@@ -50,13 +50,13 @@ bool RestartWaiter::waitFastBootDone(
         return true;
     }
 
-    return isWarmOrFastBootInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
+    return isAdvancedBootInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
 }
 
 bool RestartWaiter::doWait(DBConnector &stateDb,
                            unsigned int maxWaitSec)
 {
-    auto condFunc = [](const std::string &value) -> bool {
+    RedisTableWaiter::ConditionFunc condFunc = [](const std::string &value) -> bool {
         std::string copy = value;
         boost::to_lower(copy);
         return copy == "false";
@@ -69,7 +69,7 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
                                                condFunc);
 }
 
-bool RestartWaiter::isWarmOrFastBootInProgress(DBConnector &stateDb)
+bool RestartWaiter::isAdvancedBootInProgress(DBConnector &stateDb)
 {
     auto ret = stateDb.hget(STATE_WARM_RESTART_ENABLE_TABLE_NAME + STATE_DB_SEPARATOR + RESTART_KEY, RESTART_ENABLE_FIELD);
     if (ret) {
@@ -88,5 +88,5 @@ bool RestartWaiter::isFastBootInProgress(DBConnector &stateDb)
 
 bool RestartWaiter::isWarmBootInProgress(swss::DBConnector &stateDb)
 {
-    return isWarmOrFastBootInProgress(stateDb) && !isFastBootInProgress(stateDb);
+    return isAdvancedBootInProgress(stateDb) && !isFastBootInProgress(stateDb);
 }

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -126,11 +126,12 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
         int delay = static_cast<int>(
                     std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
 
-        selectTimeout -= delay;
-        if (selectTimeout <= 0)
+        if (delay >= static_cast<int>(maxWaitSec) * 1000)
         {
             return false;
         }
+
+        selectTimeout -= delay;
     }
 }
 

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -143,3 +143,8 @@ bool RestartWaiter::isFastRestartInProgress(DBConnector &stateDb)
     auto ret = stateDb.get(FAST_REBOOT_TABLE_NAME + STATE_DB_SEPARATOR + RESTART_KEY);
     return ret.get() != nullptr;
 }
+
+bool RestartWaiter::isWarmRestartInProgress(swss::DBConnector &stateDb)
+{
+    return isWarmOrFastRestartInProgress(stateDb) && !isFastRestartInProgress(stateDb);
+}

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -1,0 +1,130 @@
+#include "restart_waiter.h"
+#include "redispipeline.h"
+#include "select.h"
+#include "schema.h"
+#include "subscriberstatetable.h"
+#include "table.h"
+#include <string>
+
+using namespace swss;
+
+static const std::string STATE_DB_NAME = "STATE_DB";
+static const std::string STATE_DB_SEPARATOR = "|";
+static const std::string RESTART_KEY = "system";
+static const std::string RESTART_ENABLE_FIELD = "enable";
+static const std::string FAST_REBOOT_TABLE_NAME = "FAST_REBOOT";
+
+bool RestartWaiter::waitRestartDone(
+    unsigned int maxWaitSec,
+    unsigned int dbTimeout,
+    bool isTcpConn)
+{
+    DBConnector stateDb(STATE_DB_NAME, dbTimeout, isTcpConn);
+    return isWarmOrFastRestartInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
+}
+
+bool RestartWaiter::waitWarmRestartDone(unsigned int maxWaitSec,
+                                        unsigned int dbTimeout,
+                                        bool isTcpConn)
+{
+    DBConnector stateDb(STATE_DB_NAME, dbTimeout, isTcpConn);
+    if (isFastRestartInProgress(stateDb))
+    {
+        // It is fast boot, just return
+        return true;
+    }
+
+    return isWarmOrFastRestartInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
+}
+
+bool RestartWaiter::waitFastRestartDone(unsigned int maxWaitSec,
+                                        unsigned int dbTimeout,
+                                        bool isTcpConn)
+{
+    DBConnector stateDb(STATE_DB_NAME, dbTimeout, isTcpConn);
+    if (!isFastRestartInProgress(stateDb))
+    {
+        // Fast boot is not in progress
+        return true;
+    }
+
+    return isWarmOrFastRestartInProgress(stateDb) ? doWait(stateDb, maxWaitSec) : true;
+}
+
+bool RestartWaiter::doWait(DBConnector &stateDb,
+                           unsigned int maxWaitSec)
+{
+    int selectTimeout = static_cast<int>(maxWaitSec);
+
+    SubscriberStateTable restartEnableTable(&stateDb, STATE_WARM_RESTART_ENABLE_TABLE_NAME);
+    Select s;
+    s.addSelectable(&restartEnableTable);
+
+    auto start = std::chrono::steady_clock::now();
+    while (1)
+    {
+        Selectable *sel = NULL;
+        int ret = s.select(&sel, selectTimeout * 1000, true);
+
+        if (ret == Select::OBJECT)
+        {
+            KeyOpFieldsValuesTuple kco;
+            restartEnableTable.pop(kco);
+            auto &key = kfvKey(kco);
+            if (key == RESTART_KEY)
+            {
+                auto& values = kfvFieldsValues(kco);
+                for (auto& fvt: values)
+                {
+                    auto& field = fvField(fvt);
+                    auto& value = fvValue(fvt);
+                    if (field == RESTART_ENABLE_FIELD)
+                    {
+                        if (value == "false")
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        else if (ret == Select::ERROR)
+        {
+            SWSS_LOG_NOTICE("Error: wait restart done got error - %s!", strerror(errno));
+        }
+        else if (ret == Select::TIMEOUT)
+        {
+            SWSS_LOG_INFO("Timeout: wait restart done got select timeout");
+        }
+        else if (ret == Select::SIGNALINT)
+        {
+            return false;
+        }
+
+        auto end = std::chrono::steady_clock::now();
+        int delay = static_cast<int>(
+                    std::chrono::duration_cast<std::chrono::seconds>(end - start).count());
+
+        selectTimeout -= delay;
+        if (selectTimeout < 0)
+        {
+            return false;
+        }
+    }
+}
+
+bool RestartWaiter::isWarmOrFastRestartInProgress(DBConnector &stateDb)
+{
+    auto ret = stateDb.hget(STATE_WARM_RESTART_ENABLE_TABLE_NAME + STATE_DB_SEPARATOR + RESTART_KEY, RESTART_ENABLE_FIELD);
+    return ret && *ret.get() == "true";
+}
+
+bool RestartWaiter::isFastRestartInProgress(DBConnector &stateDb)
+{
+    auto ret = stateDb.get(FAST_REBOOT_TABLE_NAME + STATE_DB_SEPARATOR + RESTART_KEY);
+    return ret.get() != nullptr;
+}

--- a/common/restart_waiter.h
+++ b/common/restart_waiter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "dbconnector.h"
+
+namespace swss
+{
+
+// Helper class to wait for warm/fast reboot done
+class RestartWaiter
+{
+public:
+    static bool waitRestartDone(unsigned int maxWaitSec = 180,
+                                unsigned int dbTimeout = 0,
+                                bool isTcpConn = false);
+
+    static bool waitWarmRestartDone(unsigned int maxWaitSec = 180,
+                                    unsigned int dbTimeout = 0,
+                                    bool isTcpConn = false);
+
+    static bool waitFastRestartDone(unsigned int maxWaitSec = 180,
+                                    unsigned int dbTimeout = 0,
+                                    bool isTcpConn = false);
+
+private:
+    static bool doWait(swss::DBConnector &stateDb,
+                       unsigned int maxWaitSec);
+
+    static bool isWarmOrFastRestartInProgress(swss::DBConnector &stateDb);
+    static bool isFastRestartInProgress(swss::DBConnector &stateDb);
+};
+
+}

--- a/common/restart_waiter.h
+++ b/common/restart_waiter.h
@@ -21,12 +21,13 @@ public:
                                     unsigned int dbTimeout = 0,
                                     bool isTcpConn = false);
 
+    static bool isWarmOrFastRestartInProgress(swss::DBConnector &stateDb);
+    static bool isFastRestartInProgress(swss::DBConnector &stateDb);
+    static bool isWarmRestartInProgress(swss::DBConnector &stateDb);
+
 private:
     static bool doWait(swss::DBConnector &stateDb,
                        unsigned int maxWaitSec);
-
-    static bool isWarmOrFastRestartInProgress(swss::DBConnector &stateDb);
-    static bool isFastRestartInProgress(swss::DBConnector &stateDb);
 };
 
 }

--- a/common/restart_waiter.h
+++ b/common/restart_waiter.h
@@ -9,21 +9,21 @@ namespace swss
 class RestartWaiter
 {
 public:
-    static bool waitRestartDone(unsigned int maxWaitSec = 180,
-                                unsigned int dbTimeout = 0,
-                                bool isTcpConn = false);
+    static bool waitAdvancedBootDone(unsigned int maxWaitSec = 180,
+                                     unsigned int dbTimeout = 0,
+                                     bool isTcpConn = false);
 
-    static bool waitWarmRestartDone(unsigned int maxWaitSec = 180,
+    static bool waitWarmBootDone(unsigned int maxWaitSec = 180,
                                     unsigned int dbTimeout = 0,
                                     bool isTcpConn = false);
 
-    static bool waitFastRestartDone(unsigned int maxWaitSec = 180,
+    static bool waitFastBootDone(unsigned int maxWaitSec = 180,
                                     unsigned int dbTimeout = 0,
                                     bool isTcpConn = false);
 
-    static bool isWarmOrFastRestartInProgress(swss::DBConnector &stateDb);
-    static bool isFastRestartInProgress(swss::DBConnector &stateDb);
-    static bool isWarmRestartInProgress(swss::DBConnector &stateDb);
+    static bool isWarmOrFastBootInProgress(swss::DBConnector &stateDb);
+    static bool isFastBootInProgress(swss::DBConnector &stateDb);
+    static bool isWarmBootInProgress(swss::DBConnector &stateDb);
 
 private:
     static bool doWait(swss::DBConnector &stateDb,

--- a/common/restart_waiter.h
+++ b/common/restart_waiter.h
@@ -21,7 +21,7 @@ public:
                                     unsigned int dbTimeout = 0,
                                     bool isTcpConn = false);
 
-    static bool isWarmOrFastBootInProgress(swss::DBConnector &stateDb);
+    static bool isAdvancedBootInProgress(swss::DBConnector &stateDb);
     static bool isFastBootInProgress(swss::DBConnector &stateDb);
     static bool isWarmBootInProgress(swss::DBConnector &stateDb);
 

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -38,6 +38,7 @@
 #include "events.h"
 #include "configdb.h"
 #include "status_code_util.h"
+#include "redis_table_waiter.h"
 #include "restart_waiter.h"
 %}
 
@@ -220,4 +221,5 @@ T castSelectableObj(swss::Selectable *temp)
 %include "events.h"
 
 %include "status_code_util.h"
+#include "redis_table_waiter.h"
 %include "restart_waiter.h"

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -38,6 +38,7 @@
 #include "events.h"
 #include "configdb.h"
 #include "status_code_util.h"
+#include "restart_waiter.h"
 %}
 
 %include <std_string.i>
@@ -219,3 +220,4 @@ T castSelectableObj(swss::Selectable *temp)
 %include "events.h"
 
 %include "status_code_util.h"
+%include "restart_waiter.h"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,6 +41,7 @@ tests_SOURCES = redis_ut.cpp                \
                 events_common_ut.cpp        \
                 events_service_ut.cpp       \
                 events_ut.cpp               \
+                restart_waiter_ut.cpp       \
                 main.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,6 +42,7 @@ tests_SOURCES = redis_ut.cpp                \
                 events_service_ut.cpp       \
                 events_ut.cpp               \
                 restart_waiter_ut.cpp       \
+                redis_table_waiter_ut.cpp   \
                 main.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/redis_table_waiter_ut.cpp
+++ b/tests/redis_table_waiter_ut.cpp
@@ -44,7 +44,7 @@ TEST(RedisTableWaiter, waitUntilFieldSet)
 {
     del_key(0);
     DBConnector db(dbName, 0);
-    auto condFunc = [&](const std::string &value) -> bool {
+    RedisTableWaiter::ConditionFunc condFunc = [&](const std::string &value) -> bool {
         return value == setValue;
     };
     thread t(set_field, 1);

--- a/tests/redis_table_waiter_ut.cpp
+++ b/tests/redis_table_waiter_ut.cpp
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include <string>
+#include <unistd.h>
+
+#include "common/dbconnector.h"
+#include "common/redis_table_waiter.h"
+#include "common/table.h"
+
+using namespace swss;
+using namespace std;
+
+const std::string dbName = "STATE_DB";
+const std::string tableName = "TestTable";
+const std::string key = "testKey";
+const std::string field = "testField";
+const std::string setValue = "1234";
+
+static void set_field(int delay)
+{
+    if (delay > 0)
+    {
+        sleep(delay);
+    }
+
+    DBConnector db(dbName, 0);
+    Table table(&db, tableName);
+    table.hset(key, field, setValue);
+}
+
+static void del_key(int delay)
+{
+    if (delay > 0)
+    {
+        sleep(delay);
+    }
+
+    DBConnector db(dbName, 0);
+    Table table(&db, tableName);
+    table.del(key);
+}
+
+TEST(RedisTableWaiter, waitUntilFieldSet)
+{
+    del_key(0);
+    DBConnector db(dbName, 0);
+    auto condFunc = [&](const std::string &value) -> bool {
+        return value == setValue;
+    };
+    thread t(set_field, 1);
+    auto ret = RedisTableWaiter::waitUntilFieldSet(db,
+        tableName,
+        key,
+        field,
+        3,
+        condFunc);
+    EXPECT_TRUE(ret);
+    t.join();
+    // field already set
+    ret = RedisTableWaiter::waitUntilFieldSet(db,
+        tableName,
+        key,
+        field,
+        3,
+        condFunc);
+    EXPECT_TRUE(ret);
+}
+
+TEST(RedisTableWaiter, waitUntilKeySet)
+{
+    del_key(0);
+    DBConnector db(dbName, 0);
+    thread t(set_field, 1);
+    auto ret = RedisTableWaiter::waitUntilKeySet(db,
+        tableName,
+        key,
+        3);
+    EXPECT_TRUE(ret);
+    t.join();
+    // key already exist
+    ret = RedisTableWaiter::waitUntilKeySet(db,
+        tableName,
+        key,
+        3);
+    EXPECT_TRUE(ret);
+}
+
+TEST(RedisTableWaiter, waitUntilKeyDel)
+{
+    set_field(0);
+    DBConnector db(dbName, 0);
+    thread t(del_key, 1);
+    auto ret = RedisTableWaiter::waitUntilKeyDel(db,
+        tableName,
+        key,
+        3);
+    EXPECT_TRUE(ret);
+    t.join();
+    // key already removed
+    ret = RedisTableWaiter::waitUntilKeyDel(db,
+        tableName,
+        key,
+        3);
+    EXPECT_TRUE(ret);
+}

--- a/tests/restart_waiter_ut.cpp
+++ b/tests/restart_waiter_ut.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include "common/dbconnector.h"
+#include "common/restart_waiter.h"
+#include "common/schema.h"
+#include "common/table.h"
+
+using namespace swss;
+using namespace std;
+
+static const string FAST_REBOOT_KEY = "FAST_REBOOT|system";
+
+static void set_reboot_status(string status, int delay = 0)
+{
+    if (delay > 0)
+    {
+        sleep(delay);
+    }
+
+    DBConnector db("STATE_DB", 0);
+    Table table(&db, STATE_WARM_RESTART_ENABLE_TABLE_NAME);
+    table.hset("system", "enable", status);
+}
+
+class FastBootHelper
+{
+public:
+    FastBootHelper(): db("STATE_DB", 0)
+    {
+        db.set(FAST_REBOOT_KEY, "1");
+    }
+
+    ~FastBootHelper()
+    {
+        db.del({FAST_REBOOT_KEY});
+    }
+private:
+    DBConnector db;
+};
+
+TEST(RestartWaiter, success)
+{
+    set_reboot_status("true");
+    thread t(set_reboot_status, "false", 3);
+    EXPECT_TRUE(RestartWaiter::waitRestartDone());
+    t.join();
+}
+
+TEST(RestartWaiter, successWarmRestart)
+{
+    set_reboot_status("true");
+    thread t(set_reboot_status, "false", 3);
+    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+    t.join();
+}
+
+TEST(RestartWaiter, successFastRestart)
+{
+    FastBootHelper helper;
+    set_reboot_status("true");
+    thread t(set_reboot_status, "false", 3);
+    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+    t.join();
+}
+
+TEST(RestartWaiter, timeout)
+{
+    set_reboot_status("true");
+    EXPECT_FALSE(RestartWaiter::waitRestartDone(1));
+    EXPECT_FALSE(RestartWaiter::waitWarmRestartDone(1));
+
+    FastBootHelper helper;
+    EXPECT_FALSE(RestartWaiter::waitFastRestartDone(1));
+
+    set_reboot_status("false");
+}
+
+TEST(RestartWaiter, successNoDelay)
+{
+    set_reboot_status("false");
+    EXPECT_TRUE(RestartWaiter::waitRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+
+    FastBootHelper helper;
+    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+}
+
+TEST(RestartWaiter, successNoKey)
+{
+    DBConnector db("STATE_DB", 0);
+    string key = string(STATE_WARM_RESTART_ENABLE_TABLE_NAME) + string("|system");
+    db.del({key});
+    EXPECT_TRUE(RestartWaiter::waitRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+
+    FastBootHelper helper;
+    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+}
+
+TEST(RestartWaiter, waitWarmButFastInProgress)
+{
+    FastBootHelper helper;
+    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+}
+
+TEST(RestartWaiter, waitFastButFastNotInProgress)
+{
+    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+}

--- a/tests/restart_waiter_ut.cpp
+++ b/tests/restart_waiter_ut.cpp
@@ -46,35 +46,35 @@ TEST(RestartWaiter, success)
 {
     set_reboot_status("true");
     thread t(set_reboot_status, "false", 3);
-    EXPECT_TRUE(RestartWaiter::waitRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitAdvancedBootDone());
     t.join();
 }
 
-TEST(RestartWaiter, successWarmRestart)
+TEST(RestartWaiter, successWarmReboot)
 {
     set_reboot_status("true");
     thread t(set_reboot_status, "false", 3);
-    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitWarmBootDone());
     t.join();
 }
 
-TEST(RestartWaiter, successFastRestart)
+TEST(RestartWaiter, successFastReboot)
 {
     FastBootHelper helper;
     set_reboot_status("true");
     thread t(set_reboot_status, "false", 3);
-    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitFastBootDone());
     t.join();
 }
 
 TEST(RestartWaiter, timeout)
 {
     set_reboot_status("true");
-    EXPECT_FALSE(RestartWaiter::waitRestartDone(1));
-    EXPECT_FALSE(RestartWaiter::waitWarmRestartDone(1));
+    EXPECT_FALSE(RestartWaiter::waitAdvancedBootDone(1));
+    EXPECT_FALSE(RestartWaiter::waitWarmBootDone(1));
 
     FastBootHelper helper;
-    EXPECT_FALSE(RestartWaiter::waitFastRestartDone(1));
+    EXPECT_FALSE(RestartWaiter::waitFastBootDone(1));
 
     set_reboot_status("false");
 }
@@ -82,11 +82,11 @@ TEST(RestartWaiter, timeout)
 TEST(RestartWaiter, successNoDelay)
 {
     set_reboot_status("false");
-    EXPECT_TRUE(RestartWaiter::waitRestartDone());
-    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitAdvancedBootDone());
+    EXPECT_TRUE(RestartWaiter::waitWarmBootDone());
 
     FastBootHelper helper;
-    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitFastBootDone());
 }
 
 TEST(RestartWaiter, successNoKey)
@@ -94,20 +94,20 @@ TEST(RestartWaiter, successNoKey)
     DBConnector db("STATE_DB", 0);
     string key = string(STATE_WARM_RESTART_ENABLE_TABLE_NAME) + string("|system");
     db.del({key});
-    EXPECT_TRUE(RestartWaiter::waitRestartDone());
-    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitAdvancedBootDone());
+    EXPECT_TRUE(RestartWaiter::waitWarmBootDone());
 
     FastBootHelper helper;
-    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitFastBootDone());
 }
 
 TEST(RestartWaiter, waitWarmButFastInProgress)
 {
     FastBootHelper helper;
-    EXPECT_TRUE(RestartWaiter::waitWarmRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitWarmBootDone());
 }
 
 TEST(RestartWaiter, waitFastButFastNotInProgress)
 {
-    EXPECT_TRUE(RestartWaiter::waitFastRestartDone());
+    EXPECT_TRUE(RestartWaiter::waitFastBootDone());
 }


### PR DESCRIPTION
**Depends on:**

- https://github.com/sonic-net/sonic-sairedis/pull/1100
- https://github.com/sonic-net/sonic-utilities/pull/2286
- https://github.com/sonic-net/sonic-buildimage/pull/11594

**Why I did this?**

Daemons which are not related to warm/fast restart might affect the performance of warm/fast restart. A hardcoded start up delay is the current solution to avoid this.

This PR implements a function to wait warm/fast restart done. This function provided a efficiency and graceful way for daemons to wait warm/fast restart done.

**How I did it?**

Implement a utility function RestartWaiter::waitRestartDone. This function waits warm restart done flag in STATE DB and return true if the flag is set by warm restart finalizer. This function is also exposed as python extension so that python daemons can utilize it.

This PR depends on new fastboot design: https://github.com/sonic-net/SONiC/blob/master/doc/fast-reboot/Fast-reboot_Flow_Improvements_HLD.md

