### PR TITLE
Add DBConnector::getall() method and refactor ConfigDBConnector_Native::get_config().

### DIFF
--- a/common/configdb.cpp
+++ b/common/configdb.cpp
@@ -244,24 +244,7 @@ void ConfigDBConnector_Native::mod_config(const map<string, map<string, map<stri
 map<string, map<string, map<string, string>>> ConfigDBConnector_Native::get_config()
 {
     auto& client = get_redis_client(m_db_name);
-    auto const& keys = client.keys("*");
-    map<string, map<string, map<string, string>>> data;
-    for (string key: keys)
-    {
-        size_t pos = key.find(m_table_name_separator);
-        if (pos == string::npos) {
-            continue;
-        }
-        string table_name = key.substr(0, pos);
-        string row = key.substr(pos + 1);
-        auto const& entry = client.hgetall<map<string, string>>(key);
-
-        if (!entry.empty())
-        {
-            data[table_name][row] = entry;
-        }
-    }
-    return data;
+    return client.getall();
 }
 
 std::string ConfigDBConnector_Native::getKeySeparator() const

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -905,3 +905,26 @@ void DBConnector::del(const std::vector<std::string>& keys)
 
     pipe.flush();
 }
+
+map<string, map<string, map<string, string>>> DBConnector::getall()
+{
+    const string separator = SonicDBConfig::getSeparator(this);
+    auto const& keys = this->keys("*");
+    map<string, map<string, map<string, string>>> data;
+    for (string key: keys)
+    {
+        size_t pos = key.find(separator);
+        if (pos == string::npos) {
+            continue;
+        }
+        string table_name = key.substr(0, pos);
+        string row = key.substr(pos + 1);
+        auto const& entry = this->hgetall<map<string, string>>(key);
+
+        if (!entry.empty())
+        {
+            data[table_name][row] = entry;
+        }
+    }
+    return data;
+}

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -248,6 +248,7 @@ public:
 
     bool flushdb();
 
+    std::map<std::string, std::map<std::string, std::map<std::string, std::string>>> getall();
 private:
     void setNamespace(const std::string &netns);
 


### PR DESCRIPTION
#### Why I did it
Add DBConnector::getall() for profile provider feature.

#### How I did it
Add  DBConnector::getall() method.
Move content of ConfigDBConnector_Native::get_config() to DBConnector::getall()

#### How to verify it
Pass all existing UT and E2E test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add DBConnector::getall() method and refactor ConfigDBConnector_Native::get_config().

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

