### PR TITLE
Switch to using swig -threads flag for multithreaded features

### DIFF
--- a/pyext/py3/Makefile.am
+++ b/pyext/py3/Makefile.am
@@ -8,7 +8,7 @@ _swsscommon_la_CPPFLAGS = -std=c++11 -I../../common -I/usr/include/python$(PYTHO
 _swsscommon_la_LDFLAGS = -module
 _swsscommon_la_LIBADD = ../../common/libswsscommon.la $(PYTHON3_BLDLIBRARY)
 
-SWIG_FLAG = -Wall -c++ -python -keyword
+SWIG_FLAG = -Wall -c++ -python -keyword -threads
 if ARCH64
 SWIG_FLAG += -DSWIGWORDSIZE64
 endif

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -63,20 +63,6 @@
 %exception {
     try
     {
-        class PyThreadStateGuard
-        {
-            PyThreadState *m_save;
-        public:
-            PyThreadStateGuard()
-            {
-                m_save = PyEval_SaveThread();
-            }
-            ~PyThreadStateGuard()
-            {
-                PyEval_RestoreThread(m_save);
-            }
-        } thread_state_guard;
-
         $action
     }
     SWIG_CATCH_STDEXCEPT // catch std::exception derivatives


### PR DESCRIPTION
`-threads` is now available in swig (for both Buster and Bullseye). It also covers a couple more cases than the current code (with regards to GIL locking).

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>