### PR TITLE
Fix table dump method

### DIFF
--- a/common/table.cpp
+++ b/common/table.cpp
@@ -228,9 +228,10 @@ void Table::dump(TableDump& tableDump)
 
     lazyLoadRedisScriptFile(m_pipe->getDBConnector(), "table_dump.lua", m_shaDump);
     RedisCommand command;
-    command.format("EVALSHA %s 1 %s ''",
-            m_shaDump.c_str(),
-            getTableName().c_str());
+    command.format("EVALSHA %s 1 %s%s ''",
+                   m_shaDump.c_str(),
+                   getTableName().c_str(),
+                   getTableNameSeparator().c_str());
 
     RedisReply r = m_pipe->push(command, REDIS_REPLY_STRING);
 

--- a/common/table_dump.lua
+++ b/common/table_dump.lua
@@ -1,4 +1,4 @@
-local keys = redis.call("KEYS", KEYS[1] .. ":*")
+local keys = redis.call("KEYS", KEYS[1] .. "*")
 local res = {}
 
 for i,k in pairs(keys) do


### PR DESCRIPTION
`Table::dump` hardcode the table separator(`:`) in the Lua script. 
So it could only be used with dbs that use a colon(`:`) as the separator.
Let's pass the db separator to the `table_dump.lua`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>