### PR TITLE
keep del when del-set-sequence exist

### DIFF
--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -6,16 +6,20 @@ local keys = redis.call('SPOP', KEYS[1], ARGV[1])
 local n = table.getn(keys)
 for i = 1, n do
    local key = keys[i]
+   local fieldvalues = {}
    -- Check if there was request to delete the key, clear it in table first
    local num = redis.call('SREM', KEYS[3], key)
    if num == 1 then
       redis.call('DEL', tablename..key)
+      table.insert(ret, {key, fieldvalues})
    end
    -- Push the new set of field/value for this key in table
    local fieldvalues = redis.call('HGETALL', stateprefix..tablename..key)
-   table.insert(ret, {key, fieldvalues})
-   for i = 1, #fieldvalues, 2 do
-      redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
+   if table.getn(fieldvalues) > 0 then
+      table.insert(ret, {key, fieldvalues})
+      for i = 1, #fieldvalues, 2 do
+         redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
+      end
    end
    -- Clean up the key in temporary state table
    redis.call('DEL', stateprefix..tablename..key)


### PR DESCRIPTION
what I did:  
    when del-set-sequence exist in consumer table, I keep the del event been execute even a set of the same key is already seen after the del.
why I did:
    in the old code, the del is setting an key without fv, so if a set with fv after, it will only execute a set, so the multimap m_toSync can not  seen the del event, sometimes the lost del may result errors if something is depending on the del event.