### PR TITLE
[sonic-db-cli] Fix sonic-db-cli crash when database config file not ready issue.

### DIFF
--- a/sonic-db-cli/sonic-db-cli.cpp
+++ b/sonic-db-cli/sonic-db-cli.cpp
@@ -287,8 +287,6 @@ int sonic_db_cli(
         }
         else
         {
-            // SonicDBConfig may initialized when run cli with UT
-            initializeConfig();
             // Use the tcp connectivity if namespace is local and unixsocket cmd_option is present.
             isTcpConn = true;
             netns = "";
@@ -297,6 +295,8 @@ int sonic_db_cli(
         if (options.m_cmd.size() != 0)
         {
             auto commands = options.m_cmd;
+
+            initializeConfig();
             return executeCommands(dbOrOperation, commands, netns, isTcpConn);
         }
         else if (dbOrOperation == "PING"
@@ -307,6 +307,8 @@ int sonic_db_cli(
             // sonic-db-cli catch all possible exceptions and handle it as a failure case which not return 'OK' or 'PONG'
             try
             {
+                // When database config does not exist, sonic-db-cli will ignore exception and return 1.
+                initializeConfig();
                 return handleAllInstances(netns, dbOrOperation, isTcpConn);
             }
             catch (const exception& e)

--- a/sonic-db-cli/sonic-db-cli.cpp
+++ b/sonic-db-cli/sonic-db-cli.cpp
@@ -296,7 +296,11 @@ int sonic_db_cli(
         {
             auto commands = options.m_cmd;
 
-            initializeConfig();
+            if (netns.empty())
+            {
+                initializeConfig();
+            }
+
             return executeCommands(dbOrOperation, commands, netns, isTcpConn);
         }
         else if (dbOrOperation == "PING"
@@ -307,8 +311,12 @@ int sonic_db_cli(
             // sonic-db-cli catch all possible exceptions and handle it as a failure case which not return 'OK' or 'PONG'
             try
             {
-                // When database config does not exist, sonic-db-cli will ignore exception and return 1.
-                initializeConfig();
+                if (netns.empty())
+                {
+                    // When database_config.json does not exist, sonic-db-cli will ignore exception and return 1.
+                    initializeConfig();
+                }
+
                 return handleAllInstances(netns, dbOrOperation, isTcpConn);
             }
             catch (const exception& e)

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -11,6 +11,7 @@
 using namespace swss;
 using namespace std;
 
+const string not_exist_config_file = "./tests/redis_multi_db_ut_config/database_config_not_exist.json";
 const string config_file = "./tests/redis_multi_db_ut_config/database_config.json";
 const string global_config_file = "./tests/redis_multi_db_ut_config/database_global.json";
 
@@ -277,6 +278,47 @@ TEST(sonic_db_cli, test_cli_ping_cmd)
 
     output = runCli(3, args);
     EXPECT_EQ("True\n", output);
+}
+
+TEST(sonic_db_cli, test_cli_ping_cmd_no_config)
+{
+    char *args[3];
+    args[0] = "sonic-db-cli";
+    args[1] = "PING";
+
+    auto output = runCli(2, args);
+    EXPECT_EQ("PONG\n", output);
+
+    // When ping with DB name, result should be 'True'
+    args[0] = "sonic-db-cli";
+    args[1] = "TEST_DB";
+    args[2] = "PING";
+
+    // data base file does not exist, will throw exception
+    auto initializeGlobalConfig = []()
+    {
+        if (!SonicDBConfig::isGlobalInit())
+        {
+            SonicDBConfig::initializeGlobalConfig(not_exist_config_file);
+        }
+    };
+
+    auto initializeConfig = []()
+    {
+        if (!SonicDBConfig::isInit())
+        {
+            SonicDBConfig::initialize(not_exist_config_file);
+        }
+    };
+
+    optind = 0;
+    int exit_code = sonic_db_cli(
+                    3,
+                    args,
+                    initializeGlobalConfig,
+                    initializeConfig);
+
+    EXPECT_EQ(1, exit_code);
 }
 
 TEST(sonic_db_cli, test_cli_save_cmd)

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -311,19 +311,6 @@ TEST(sonic_db_cli, test_cli_ping_cmd_no_config)
                     initializeConfig);
 
     EXPECT_EQ(1, exit_code);
-
-    args[0] = "sonic-db-cli";
-    args[1] = "TEST_DB";
-    args[2] = "PING";
-
-    optind = 0;
-    exit_code = sonic_db_cli(
-                    3,
-                    args,
-                    initializeGlobalConfig,
-                    initializeConfig);
-
-    EXPECT_EQ(1, exit_code);
 }
 
 TEST(sonic_db_cli, test_cli_save_cmd)

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -286,14 +286,6 @@ TEST(sonic_db_cli, test_cli_ping_cmd_no_config)
     args[0] = "sonic-db-cli";
     args[1] = "PING";
 
-    auto output = runCli(2, args);
-    EXPECT_EQ("PONG\n", output);
-
-    // When ping with DB name, result should be 'True'
-    args[0] = "sonic-db-cli";
-    args[1] = "TEST_DB";
-    args[2] = "PING";
-
     // data base file does not exist, will throw exception
     auto initializeGlobalConfig = []()
     {
@@ -313,6 +305,19 @@ TEST(sonic_db_cli, test_cli_ping_cmd_no_config)
 
     optind = 0;
     int exit_code = sonic_db_cli(
+                    2,
+                    args,
+                    initializeGlobalConfig,
+                    initializeConfig);
+
+    EXPECT_EQ(1, exit_code);
+
+    args[0] = "sonic-db-cli";
+    args[1] = "TEST_DB";
+    args[2] = "PING";
+
+    optind = 0;
+    exit_code = sonic_db_cli(
                     3,
                     args,
                     initializeGlobalConfig,

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -289,18 +289,12 @@ TEST(sonic_db_cli, test_cli_ping_cmd_no_config)
     // data base file does not exist, will throw exception
     auto initializeGlobalConfig = []()
     {
-        if (!SonicDBConfig::isGlobalInit())
-        {
-            SonicDBConfig::initializeGlobalConfig(not_exist_config_file);
-        }
+        SonicDBConfig::initializeGlobalConfig(not_exist_config_file);
     };
 
     auto initializeConfig = []()
     {
-        if (!SonicDBConfig::isInit())
-        {
-            SonicDBConfig::initialize(not_exist_config_file);
-        }
+        SonicDBConfig::initialize(not_exist_config_file);
     };
 
     optind = 0;

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -305,6 +305,28 @@ TEST(sonic_db_cli, test_cli_ping_cmd_no_config)
                     initializeConfig);
 
     EXPECT_EQ(1, exit_code);
+
+    // When ping with DB name, exception will happen
+    args[0] = "sonic-db-cli";
+    args[1] = "TEST_DB";
+    args[2] = "PING";
+
+    bool exception_happen = false;
+    try
+    {
+        optind = 0;
+        exit_code = sonic_db_cli(
+                        3,
+                        args,
+                        initializeGlobalConfig,
+                        initializeConfig);
+    }
+    catch (const exception& e)
+    {
+        exception_happen = true;
+    }
+
+    EXPECT_EQ(true, exception_happen);
 }
 
 TEST(sonic_db_cli, test_cli_save_cmd)


### PR DESCRIPTION
#### Why I did it
Fix sonic-db-cli  PING/SAVE/FLUSHALL command crash when database config file not ready issue:
https://github.com/sonic-net/sonic-buildimage/issues/12047

#### How I did it
When run PING/SAVE/FLUSHALL command, catch database initialize failed exception and return 1.

#### How to verify it
Pass all existing UT and E2E test.
Add new UT to cover changed code.
Manually test, sonic-db-cli will return 1 when run PING command and can't find config file:

azureuser@a7f66d2b794c:/sonic/src/sonic-swss-common$ ./sonic-db-cli/sonic-db-cli PING
An exception of type Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json occurred. Arguments:
/sonic/src/sonic-swss-common/sonic-db-cli/.libs/sonic-db-cli PING
azureuser@a7f66d2b794c:/sonic/src/sonic-swss-common$ echo $?
1


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
Fix sonic-db-cli  PING/SAVE/FLUSHALL command crash when database config file not ready issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

