### PR TITLE
Update libboost-serialization1.71 to libboost-serialization-dev to use highest version available

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -30,7 +30,7 @@ function build_and_install_kmodule()
     apt-get install -y flex bison libssl-dev libelf-dev
     apt-get install -y libnl-route-3-200 libnl-route-3-dev libnl-cli-3-200 libnl-cli-3-dev libnl-3-dev
     # Install libs required by libswsscommon for build
-    apt-get install -y libzmq3-dev libzmq5 libboost-serialization1.71.0 uuid-dev
+    apt-get install -y libzmq3-dev libzmq5 libboost-serialization1.74.0 uuid-dev
 
     # Add the apt source mirrors and download the linux image source code
     cp /etc/apt/sources.list /etc/apt/sources.list.bk

--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -30,7 +30,7 @@ function build_and_install_kmodule()
     apt-get install -y flex bison libssl-dev libelf-dev
     apt-get install -y libnl-route-3-200 libnl-route-3-dev libnl-cli-3-200 libnl-cli-3-dev libnl-3-dev
     # Install libs required by libswsscommon for build
-    apt-get install -y libzmq3-dev libzmq5 libboost-serialization1.74.0 uuid-dev
+    apt-get install -y libzmq3-dev libzmq5 libboost-serialization libboost-serialization-dev uuid-dev
 
     # Add the apt source mirrors and download the linux image source code
     cp /etc/apt/sources.list /etc/apt/sources.list.bk

--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -30,7 +30,7 @@ function build_and_install_kmodule()
     apt-get install -y flex bison libssl-dev libelf-dev
     apt-get install -y libnl-route-3-200 libnl-route-3-dev libnl-cli-3-200 libnl-cli-3-dev libnl-3-dev
     # Install libs required by libswsscommon for build
-    apt-get install -y libzmq3-dev libzmq5 libboost-serialization libboost-serialization-dev uuid-dev
+    apt-get install -y libzmq3-dev libzmq5 libboost-serialization-dev uuid-dev
 
     # Add the apt source mirrors and download the linux image source code
     cp /etc/apt/sources.list /etc/apt/sources.list.bk

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
         sudo apt-get update
         sudo apt-get install -y make libtool m4 autoconf dh-exec debhelper cmake pkg-config \
                          libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev swig3.0 \
-                         libpython2.7-dev libboost-dev libboost1.74-dev libboost-serialization-dev uuid-dev libzmq5 libzmq3-dev
+                         libpython2.7-dev libboost-dev libboost1.71-dev libboost-serialization-dev uuid-dev libzmq5 libzmq3-dev
         sudo apt-get install -y sudo
         sudo apt-get install -y redis-server redis-tools
         sudo apt-get install -y python3-pip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
         sudo apt-get update
         sudo apt-get install -y make libtool m4 autoconf dh-exec debhelper cmake pkg-config \
                          libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev swig3.0 \
-                         libpython2.7-dev libboost-dev libboost1.71-dev libboost-serialization-dev uuid-dev libzmq5 libzmq3-dev
+                         libpython2.7-dev libboost-dev libboost1.74-dev libboost-serialization-dev uuid-dev libzmq5 libzmq3-dev
         sudo apt-get install -y sudo
         sudo apt-get install -y redis-server redis-tools
         sudo apt-get install -y python3-pip


### PR DESCRIPTION
Motivation: 

Currently we specify swss-common to use libboost-serialization1.71 to be used which is fine when building swss-common inside of slave-buster container. However, when building swss-common inside bullseye, libboost-serialization1.71 is not supported. We have installed libboost-serialization1.74 inside bullseye and are making change in swss-common to use highest version of libboost-serialization available (1.71 for buster or 1.74 for bullseye)