### PR TITLE
[cherry-pick] [201911] Throw proper exceptions when talking with Redis

### DIFF
--- a/common/redisreply.cpp
+++ b/common/redisreply.cpp
@@ -29,15 +29,37 @@ inline void guard(FUNC func, const char* command)
 
 RedisReply::RedisReply(DBConnector *db, const RedisCommand& command)
 {
-    redisAppendFormattedCommand(db->getContext(), command.c_str(), command.length());
-    redisGetReply(db->getContext(), (void**)&m_reply);
+    int rc = redisAppendFormattedCommand(db->getContext(), command.c_str(), command.length());
+    if (rc != REDIS_OK)
+    {
+        // The only reason of error is REDIS_ERR_OOM (Out of memory)
+        // ref: https://github.com/redis/hiredis/blob/master/hiredis.c
+        throw bad_alloc();
+    }
+
+    rc = redisGetReply(db->getContext(), (void**)&m_reply);
+    if (rc != REDIS_OK)
+    {
+        throw RedisError("Failed to redisGetReply with " + string(command.c_str()), db->getContext());
+    }
     guard([&]{checkReply();}, command.c_str());
 }
 
 RedisReply::RedisReply(DBConnector *db, const string &command)
 {
-    redisAppendCommand(db->getContext(), command.c_str());
-    redisGetReply(db->getContext(), (void**)&m_reply);
+    int rc = redisAppendCommand(db->getContext(), command.c_str());
+    if (rc != REDIS_OK)
+    {
+        // The only reason of error is REDIS_ERR_OOM (Out of memory)
+        // ref: https://github.com/redis/hiredis/blob/master/hiredis.c
+        throw bad_alloc();
+    }
+
+    rc = redisGetReply(db->getContext(), (void**)&m_reply);
+    if (rc != REDIS_OK)
+    {
+        throw RedisError("Failed to redisGetReply with " + command, db->getContext());
+    }
     guard([&]{checkReply();}, command.c_str());
 }
 

--- a/common/redisreply.h
+++ b/common/redisreply.h
@@ -2,11 +2,37 @@
 #define __REDISREPLY__
 
 #include <hiredis/hiredis.h>
+#include <string>
 #include <stdexcept>
 #include "dbconnector.h"
 #include "rediscommand.h"
 
 namespace swss {
+
+class DBConnector;
+
+class RedisError : public std::runtime_error
+{
+    int m_err;
+    std::string m_errstr;
+    mutable std::string m_message;
+public:
+    RedisError(const std::string& arg, redisContext *ctx)
+        : std::runtime_error(arg)
+        , m_err(ctx->err)
+        , m_errstr(ctx->errstr)
+    {
+    }
+
+    const char *what() const noexcept override
+    {
+        if (m_message.empty())
+        {
+            m_message = std::string("RedisResponseError: ") + std::runtime_error::what() + ", err=" + std::to_string(m_err) + ": errstr=" + m_errstr;
+        }
+        return m_message.c_str();
+    }
+};
 
 class RedisReply
 {


### PR DESCRIPTION
This is a manually cherry pick of https://github.com/sonic-net/sonic-swss-common/pull/384 , because there is merge conflict happen.

* Add new exception RedisResponseError
* Rename to RedisError
* Throw bad_alloc when ouf of memory
* Handle and throw exception in RedisPipeline