### PR TITLE
[CI]Install libyang from common-lib when build bullseye

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -99,7 +99,7 @@ jobs:
   - script: |
       set -ex
       sudo dpkg -i $(find ./download -name *.deb)
-    workingDirectory: $(Build.ArtifactStagingDirectory)/download
+    workingDirectory: $(Build.ArtifactStagingDirectory)
     condition: ne('${{ parameters.debian_version }}', 'bullseye')
     displayName: "Install libyang from common lib"
   - script: |

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -102,10 +102,8 @@ jobs:
     workingDirectory: $(Build.ArtifactStagingDirectory)
     condition: ne('${{ parameters.debian_version }}', 'bullseye')
     displayName: "Install libyang from common lib"
-    # Azure.sonic-buildimage.common_libs does not build libs for bullseye, so install libyang-dev by apt-get
   - script: |
-      sudo apt-get install -qq -y \
-        libyang-dev
+        sudo dpkg -i libyang*.deb
     condition: eq('${{ parameters.debian_version }}', 'bullseye')
     displayName: "Install libyang for bullseye"
   - script: |

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -100,7 +100,6 @@ jobs:
       set -ex
       sudo dpkg -i $(find ./download -name *.deb)
     workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: ne('${{ parameters.debian_version }}', 'bullseye')
     displayName: "Install libyang from common lib"
   - script: |
       set -ex

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -99,13 +99,9 @@ jobs:
   - script: |
       set -ex
       sudo dpkg -i $(find ./download -name *.deb)
-    workingDirectory: $(Build.ArtifactStagingDirectory)
+    workingDirectory: $(Build.ArtifactStagingDirectory)/download
     condition: ne('${{ parameters.debian_version }}', 'bullseye')
     displayName: "Install libyang from common lib"
-  - script: |
-        sudo dpkg -i libyang*.deb
-    condition: eq('${{ parameters.debian_version }}', 'bullseye')
-    displayName: "Install libyang for bullseye"
   - script: |
       set -ex
       rm ../*.deb || true


### PR DESCRIPTION
Why I did it
sonic-gnmi need use libswss-common bullseye artifact from this pipeline.

How I did it
Modify azure pipeline to install libyang from common-libs artifact.

How to verify it
Pass all UT.

Which release branch to backport (provide reason below if selected)
 201811
 201911
 202006
 202012
 202106
 202111
Description for the changelog
sonic-gnmi need use libswss-common bullseye artifact from this pipeline.

Link to config_db schema for YANG module changes
A picture of a cute animal (not mandatory but encouraged)