### PR TITLE
Install swsscommon.i with libswsscommon-dev

### DIFF
--- a/debian/libswsscommon-dev.install
+++ b/debian/libswsscommon-dev.install
@@ -1,2 +1,3 @@
 common/*.h usr/include/swss
 common/*.hpp usr/include/swss
+pyext/swsscommon.i usr/share/swss


### PR DESCRIPTION
#### Why I did it
sonic-gnmi needs to reuse swsscommon.i

#### How I did it
Install swsscommon.i with libswsscommon-dev

#### How to verify it
Install libswsscommon-dev and check /usr/share/swss

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Install swsscommon.i with libswsscommon-dev.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

