### PR TITLE
Support for TC-DOT1p qos map

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -332,6 +332,7 @@ namespace swss {
 #define CFG_DSCP_TO_FC_MAP_TABLE_NAME               "DSCP_TO_FC_MAP"
 #define CFG_EXP_TO_FC_MAP_TABLE_NAME                "EXP_TO_FC_MAP"
 #define CFG_TC_TO_DSCP_MAP_TABLE_NAME               "TC_TO_DSCP_MAP"
+#define CFG_TC_TO_DOT1P_MAP_TABLE_NAME              "TC_TO_DOT1P_MAP"
 
 #define CFG_BUFFER_POOL_TABLE_NAME                  "BUFFER_POOL"
 #define CFG_BUFFER_PROFILE_TABLE_NAME               "BUFFER_PROFILE"


### PR DESCRIPTION
Refer to https://github.com/sonic-net/sonic-swss/pull/2559

This PR has been raised to enable support for tc-dot1p qos map configuration. The above mentioned PR is dependent on this commit.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, not features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ x] 202205