### PR TITLE
Switch to using stock gcovr 5.2 (#726)

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -73,14 +73,14 @@ jobs:
   - ${{ if eq(parameters.run_unit_test, true) }}:
     - script: |
         set -ex
-        git clone https://github.com/Spacetown/gcovr.git
+        git clone https://github.com/gcovr/gcovr.git
         cd gcovr/
-        git checkout origin/recursive_search_file
+        git checkout 5.2
         sudo pip3 install setuptools
         sudo python3 setup.py install
         cd ..
         sudo rm -rf gcovr
-      displayName: "Install gcovr 5.0 with recursive fix"
+      displayName: "Install gcovr 5.2 (for --exclude-throw-branches support)"
     - script: |
         set -ex
         sudo pip install Pympler==0.8
@@ -98,7 +98,7 @@ jobs:
         redis-cli FLUSHALL
         pytest --cov=. --cov-report=xml
         mv coverage.xml tests/coverage.xml
-        gcovr -r ./ -e ".*/swsscommon_wrap.cpp" --exclude-unreachable-branches --exclude-throw-branches -x --xml-pretty  -o coverage.xml
+        gcovr -r ./ -e ".*/swsscommon_wrap.cpp" --exclude-unreachable-branches --exclude-throw-branches --gcov-ignore-parse-errors -x --xml-pretty  -o coverage.xml
       displayName: "Run swss common unit tests"
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: ${{ parameters.artifact_name }}

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -4,14 +4,7 @@ ARG docker_container_name
 
 ADD ["debs", "/debs"]
 
-RUN dpkg --purge python-swsscommon
-RUN dpkg --purge python3-swsscommon
-RUN dpkg --purge swss
-RUN dpkg --purge libsairedis
-RUN dpkg --purge libswsscommon
-RUN dpkg --purge libsaimetadata
-RUN dpkg --purge libsaivs
-RUN dpkg --purge syncd-vs
+RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-cli libswsscommon libsaimetadata libsaivs syncd-vs
 
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -16,6 +16,7 @@ RUN dpkg --purge syncd-vs
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python3-swsscommon_1.0.0_amd64.deb
+RUN dpkg -i /debs/sonic-db-cli_1.0.0_amd64.deb
 
 RUN dpkg -i /debs/libsaimetadata_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb


### PR DESCRIPTION
* Switch to using stock gcovr 5.2

The custom branch we were using previously has since been deleted. That branch appears to have some fix for searching for the source file (for a gcda file) recursively. I don't know if it's needed or not today, but using the stock gcovr 5.2 (from the official repo) appears to work.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>