### PR TITLE
Change the dtor of ProducerStateTable to virtual method

### DIFF
--- a/common/producerstatetable.h
+++ b/common/producerstatetable.h
@@ -12,7 +12,7 @@ class ProducerStateTable : public TableBase, public TableName_KeySet
 public:
     ProducerStateTable(DBConnector *db, const std::string &tableName);
     ProducerStateTable(RedisPipeline *pipeline, const std::string &tableName, bool buffered = false);
-    ~ProducerStateTable();
+    virtual ~ProducerStateTable();
 
     void setBuffered(bool buffered);
     /* Implements set() and del() commands using notification messages */


### PR DESCRIPTION
#### Why I did it
Make ProducerStateTable class inheritable. 

#### How I did it
Change the dtor of ProducerStateTable to virtual method.

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Change the dtor of ProducerStateTable to virtual method.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

