### PR TITLE
Increase the netlink buffer size from 3MB to 16MB.

### DIFF
--- a/common/netlink.cpp
+++ b/common/netlink.cpp
@@ -35,8 +35,8 @@ NetLink::NetLink(int pri) :
     }
 
     nl_socket_set_nonblocking(m_socket);
-    /* Set socket buffer size to 3MB */
-    nl_socket_set_buffer_size(m_socket, 3145728, 0);
+    /* Set socket buffer size to 16MB */
+    nl_socket_set_buffer_size(m_socket, 16777216, 0);
 }
 
 NetLink::~NetLink()


### PR DESCRIPTION
As error is seen in fdbsyncd with netlink reports "out of memory on reading a netlink socket" It is seen when kernel is sending 10k remote mac to fdbsyncd.

- What I did
    Increase the buffer size of the netlink buffer from 3MB to 16MB

- How I did it
    Increase the buffer size in the API nl_socket_set_buffer_size

- How to verify it
    Verified with 10k remote mac, and restarting the fdbsyncd process. So that kernel send the bridge fdb dump to the fdbsyncd.
    Verified that the netlink buffer error is not reported in the sys log.

Signed-off-by: kishore.kunal@broadcom.com