### PR TITLE
[202205] Fix epoll and socket resource leak issue. (#651)

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -149,6 +149,12 @@ T castSelectableObj(swss::Selectable *temp)
 %template(CastSelectableToRedisSelectObj) castSelectableObj<swss::RedisSelect *>;
 %template(CastSelectableToSubscriberTableObj) castSelectableObj<swss::SubscriberStateTable *>;
 
+// Handle object ownership issue with %newobject:
+//        https://www.swig.org/Doc4.0/SWIGDocumentation.html#Customization_ownership
+// %newobject must declared before %include header files
+%newobject swss::DBConnector::pubsub;
+%newobject swss::DBConnector::newConnector;
+
 %include "schema.h"
 %include "dbconnector.h"
 %include "sonicv2connector.h"


### PR DESCRIPTION
Cherry-picking this #651 for 202205 branch.

#### Why I did it
Fix epoll and socket resurce leak issue:
[chassis] Too many open files error and unable to connect to redis socket error https://github.com/Azure/sonic-buildimage/issues/10870

The reason of this issue is in SWIG any method return a new object need decorate with %newobject, so SWIG will generate code to release C++ object when python wrapper object released: https://www.swig.org/Doc4.0/SWIGDocumentation.html#Customization_ownership


#### How I did it
Update swsscommon.i to decorate return new object methods with %newobject

#### How to verify it
Pass all test case.

Run following code in python and validate there is no epoll and socket leak:

from swsscommon.swsscommon import SonicDBConfig
from swsscommon.swsscommon import SonicV2Connector import gc

SonicDBConfig.load_sonic_global_db_config()
SonicDBConfig.get_ns_list()
db = SonicV2Connector(use_unix_socket_path=True, namespace='') db.connect("CONFIG_DB")
db.get_redis_client("CONFIG_DB")
client = db.get_redis_client("CONFIG_DB")
client.pubsub()
client.pubsub()
client.pubsub()
client.newConnector(0)
client.newConnector(0)
client.newConnector(0)

gc.collect()

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006 -->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Fix epoll and socket resurce leak issue:
[chassis] Too many open files error and unable to connect to redis socket error https://github.com/Azure/sonic-buildimage/issues/10870

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)