### PR TITLE
Update restart_waiter_ut

### DIFF
--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -11,7 +11,7 @@ static const std::string STATE_DB_NAME = "STATE_DB";
 static const std::string STATE_DB_SEPARATOR = "|";
 static const std::string RESTART_KEY = "system";
 static const std::string RESTART_ENABLE_FIELD = "enable";
-static const std::string FAST_REBOOT_TABLE_NAME = "FAST_REBOOT";
+static const std::string FAST_REBOOT_TABLE_NAME = "FAST_RESTART_ENABLE_TABLE";
 
 // waitAdvancedBootDone
 bool RestartWaiter::waitAdvancedBootDone(

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -77,7 +77,7 @@ bool RestartWaiter::isAdvancedBootInProgress(DBConnector &stateDb)
 bool RestartWaiter::isAdvancedBootInProgressHelper(DBConnector &stateDb,
                                                    bool checkFastBoot)
 {
-    string table_name = checkFastBoot ? FAST_REBOOT_TABLE_NAME : STATE_WARM_RESTART_ENABLE_TABLE_NAME;
+    std::string table_name = checkFastBoot ? FAST_REBOOT_TABLE_NAME : STATE_WARM_RESTART_ENABLE_TABLE_NAME;
     auto ret = stateDb.hget(table_name + STATE_DB_SEPARATOR + RESTART_KEY, RESTART_ENABLE_FIELD);
     if (ret) {
         std::string value = *ret.get();

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -71,7 +71,14 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
 
 bool RestartWaiter::isAdvancedBootInProgress(DBConnector &stateDb)
 {
-    auto ret = stateDb.hget(STATE_WARM_RESTART_ENABLE_TABLE_NAME + STATE_DB_SEPARATOR + RESTART_KEY, RESTART_ENABLE_FIELD);
+    return isAdvancedBootInProgress(stateDb);
+}
+
+bool RestartWaiter::isAdvancedBootInProgressHelper(DBConnector &stateDb,
+                                                   bool checkFastBoot)
+{
+    string table_name = checkFastBoot ? FAST_REBOOT_TABLE_NAME : STATE_WARM_RESTART_ENABLE_TABLE_NAME;
+    auto ret = stateDb.hget(table_name + STATE_DB_SEPARATOR + RESTART_KEY, RESTART_ENABLE_FIELD);
     if (ret) {
         std::string value = *ret.get();
         boost::to_lower(value);
@@ -82,8 +89,7 @@ bool RestartWaiter::isAdvancedBootInProgress(DBConnector &stateDb)
 
 bool RestartWaiter::isFastBootInProgress(DBConnector &stateDb)
 {
-    auto ret = stateDb.get(FAST_REBOOT_TABLE_NAME + STATE_DB_SEPARATOR + RESTART_KEY);
-    return ret.get() != nullptr;
+    return isAdvancedBootInProgressHelper(stateDb, true);
 }
 
 bool RestartWaiter::isWarmBootInProgress(swss::DBConnector &stateDb)

--- a/common/restart_waiter.cpp
+++ b/common/restart_waiter.cpp
@@ -71,7 +71,7 @@ bool RestartWaiter::doWait(DBConnector &stateDb,
 
 bool RestartWaiter::isAdvancedBootInProgress(DBConnector &stateDb)
 {
-    return isAdvancedBootInProgress(stateDb);
+    return isAdvancedBootInProgressHelper(stateDb);
 }
 
 bool RestartWaiter::isAdvancedBootInProgressHelper(DBConnector &stateDb,

--- a/common/restart_waiter.h
+++ b/common/restart_waiter.h
@@ -20,7 +20,9 @@ public:
     static bool waitFastBootDone(unsigned int maxWaitSec = 180,
                                     unsigned int dbTimeout = 0,
                                     bool isTcpConn = false);
-
+    
+    static bool isAdvancedBootInProgressHelper(swss::DBConnector &stateDb,
+                                                bool checkFastBoot = false)
     static bool isAdvancedBootInProgress(swss::DBConnector &stateDb);
     static bool isFastBootInProgress(swss::DBConnector &stateDb);
     static bool isWarmBootInProgress(swss::DBConnector &stateDb);

--- a/common/restart_waiter.h
+++ b/common/restart_waiter.h
@@ -22,7 +22,7 @@ public:
                                     bool isTcpConn = false);
     
     static bool isAdvancedBootInProgressHelper(swss::DBConnector &stateDb,
-                                                bool checkFastBoot = false)
+                                                bool checkFastBoot = false);
     static bool isAdvancedBootInProgress(swss::DBConnector &stateDb);
     static bool isFastBootInProgress(swss::DBConnector &stateDb);
     static bool isWarmBootInProgress(swss::DBConnector &stateDb);

--- a/tests/restart_waiter_ut.cpp
+++ b/tests/restart_waiter_ut.cpp
@@ -31,12 +31,12 @@ class FastBootHelper
 public:
     FastBootHelper(): db("STATE_DB", 0)
     {
-        db.set(FAST_REBOOT_KEY, "1");
+        db.set(FAST_REBOOT_KEY, "enable");
     }
 
     ~FastBootHelper()
     {
-        db.del({FAST_REBOOT_KEY});
+        db.set(FAST_REBOOT_KEY, "disable");
     }
 private:
     DBConnector db;

--- a/tests/restart_waiter_ut.cpp
+++ b/tests/restart_waiter_ut.cpp
@@ -12,7 +12,7 @@
 using namespace swss;
 using namespace std;
 
-static const string FAST_REBOOT_KEY = "FAST_REBOOT|system";
+static const string FAST_REBOOT_KEY = "FAST_RESTART_ENABLE_TABLE|system";
 
 static void set_reboot_status(string status, int delay = 0)
 {

--- a/tests/restart_waiter_ut.cpp
+++ b/tests/restart_waiter_ut.cpp
@@ -31,12 +31,12 @@ class FastBootHelper
 public:
     FastBootHelper(): db("STATE_DB", 0)
     {
-        db.set(FAST_REBOOT_KEY, "enable");
+        db.hset(FAST_REBOOT_KEY, "enable", "true");
     }
 
     ~FastBootHelper()
     {
-        db.set(FAST_REBOOT_KEY, "disable");
+        db.hset(FAST_REBOOT_KEY, "enable", "false");
     }
 private:
     DBConnector db;


### PR DESCRIPTION
Update restart_waiter_ut to use "enable"/"disable" as values for fast-reboot entry in state-db.

This PR should come along with the following PRs:
https://github.com/sonic-net/sonic-utilities/pull/2621
https://github.com/sonic-net/sonic-buildimage/pull/13484
https://github.com/sonic-net/sonic-platform-daemons/pull/335
https://github.com/sonic-net/sonic-sairedis/pull/1196

This set of PRs solves the issue https://github.com/sonic-net/sonic-buildimage/issues/13251