### PR TITLE
[CI][202012]: Swap the python code coverage report with the cpp report (#544)

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -77,7 +77,9 @@ jobs:
 
         ./tests/tests
         redis-cli FLUSHALL
-        pytest
+        pytest --cov=. --cov-report=xml
+        mv coverage.xml tests/coverage.xml
+        gcovr -r ./ -e ".*/swsscommon_wrap.cpp" --exclude-unreachable-branches --exclude-throw-branches -x --xml-pretty  -o coverage.xml
       displayName: "Run swss common unit tests"
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: ${{ parameters.artifact_name }}


### PR DESCRIPTION
Change to show CPP code full coverage, make the coverage rate the same as it displayed in the coverage page.