### PR TITLE
[CI] Update path to sairedis tests

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -129,7 +129,7 @@ jobs:
       ./autogen.sh
       DEB_BUILD_OPTIONS=nocheck fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc)
       # Add SYS_TIME capability for settimeofday ok in syncd test
-      sudo setcap "cap_sys_time=eip" syncd/.libs/tests
+      sudo setcap "cap_sys_time=eip" syncd/.libs/syncd_tests
       make check
       mv ../*.deb .
     displayName: "Compile sonic sairedis"


### PR DESCRIPTION
The path to the sairedis test binary (for `setcap`) has changed after sonic-net/sonic-sairedis#1197. Update the path here.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>