### PR TITLE
Prevent sonic-db-cli generate core dump

### DIFF
--- a/sonic-db-cli/main.cpp
+++ b/sonic-db-cli/main.cpp
@@ -17,28 +17,9 @@ int main(int argc, char** argv)
         SonicDBConfig::initialize(SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_FILE);
     };
 
-
-    try
-    {
-        return sonic_db_cli(
-                        argc,
-                        argv,
-                        initializeGlobalConfig,
-                        initializeConfig);
-    }
-    catch (const exception& e)
-    {
-        // sonic-db-cli is porting from python version.
-        // in python version, when any exception happen sonic-db-cli will crash but will not generate core dump file.
-        // catch all exception here to avoid a core dump file generated.
-        cerr << "An exception of type " << e.what() << " occurred. Arguments:" << endl;
-        for (int idx = 0; idx < argc; idx++)
-        {
-            cerr << argv[idx]  << " ";
-        }
-        cerr << endl;
-
-        // when python version crash, exit code is 1.
-        return 1;
-    }
+    return cli_exception_wrapper(
+                    argc,
+                    argv,
+                    initializeGlobalConfig,
+                    initializeConfig);
 }

--- a/sonic-db-cli/main.cpp
+++ b/sonic-db-cli/main.cpp
@@ -16,9 +16,28 @@ int main(int argc, char** argv)
         SonicDBConfig::initialize(SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_FILE);
     };
 
-    return sonic_db_cli(
-                    argc,
-                    argv,
-                    initializeGlobalConfig,
-                    initializeConfig);
+
+    try
+    {
+        return sonic_db_cli(
+                        argc,
+                        argv,
+                        initializeGlobalConfig,
+                        initializeConfig);
+    }
+    catch (const exception& e)
+    {
+        // sonic-db-cli is porting from python version.
+        // in python version, when any exception happen sonic-db-cli will crash but will not generate core dump file.
+        // catch all exception here to avoid a core dump file generated.
+        cerr << "An exception of type " << e.what() << " occurred. Arguments:" << endl;
+        for (int idx = 0; idx < argc; idx++)
+        {
+            cerr << argv[idx]  << " ";
+        }
+        cerr << endl;
+
+        // when python version crash, exit code is 1.
+        return 1;
+    }
 }

--- a/sonic-db-cli/main.cpp
+++ b/sonic-db-cli/main.cpp
@@ -1,5 +1,6 @@
 #include "sonic-db-cli.h"
 #include "common/dbconnector.h"
+#include <iostream>
 
 using namespace swss;
 using namespace std;

--- a/sonic-db-cli/sonic-db-cli.cpp
+++ b/sonic-db-cli/sonic-db-cli.cpp
@@ -343,6 +343,38 @@ int sonic_db_cli(
     return 0;
 }
 
+
+int cli_exception_wrapper(
+    int argc,
+    char** argv,
+    function<void()> initializeGlobalConfig,
+    function<void()> initializeConfig)
+{
+    try
+    {
+        return sonic_db_cli(
+                        argc,
+                        argv,
+                        initializeGlobalConfig,
+                        initializeConfig);
+    }
+    catch (const exception& e)
+    {
+        // sonic-db-cli is porting from python version.
+        // in python version, when any exception happen sonic-db-cli will crash but will not generate core dump file.
+        // catch all exception here to avoid a core dump file generated.
+        cerr << "An exception of type " << e.what() << " occurred. Arguments:" << endl;
+        for (int idx = 0; idx < argc; idx++)
+        {
+            cerr << argv[idx]  << " ";
+        }
+        cerr << endl;
+
+        // when python version crash, exit code is 1.
+        return 1;
+    }
+}
+
 string getCommandName(vector<string>& commands)
 {
     if (commands.size() == 0)

--- a/sonic-db-cli/sonic-db-cli.h
+++ b/sonic-db-cli/sonic-db-cli.h
@@ -54,4 +54,10 @@ int sonic_db_cli(
     std::function<void()> initializeGlobalConfig,
     std::function<void()> initializeConfig);
 
+int cli_exception_wrapper(
+    int argc,
+    char** argv,
+    std::function<void()> initializeGlobalConfig,
+    std::function<void()> initializeConfig);
+
 std::string getCommandName(std::vector<std::string>& command);

--- a/tests/cli_ut.cpp
+++ b/tests/cli_ut.cpp
@@ -508,3 +508,35 @@ TEST(sonic_db_cli, test_parallel_cmd) {
     auto parallen_time = float( clock () - begin_time );
     EXPECT_TRUE(parallen_time < sequential_time);
 }
+
+TEST(sonic_db_cli, test_cli_not_throw_exception)
+{
+    char *args[5];
+    args[0] = "sonic-db-cli";
+    args[1] = "TEST_DB";
+    
+    // set key to test DB
+    args[2] = "SET";
+    args[3] = "testkey";
+    args[4] = "testvalue";
+
+    // data base file does not exist, will throw exception
+    auto initializeGlobalConfig = []()
+    {
+        throw std::system_error();
+    };
+
+    auto initializeConfig = []()
+    {
+        throw std::system_error();
+    };
+
+    optind = 0;
+    int exit_code = cli_exception_wrapper(
+                        5,
+                        args,
+                        initializeGlobalConfig,
+                        initializeConfig);
+
+    EXPECT_EQ(1, exit_code);
+}


### PR DESCRIPTION
#### Why I did it
sonic-db-cli is porting from python version. in python version, when any exception happen sonic-db-cli will crash but will not generate core dump file. but in c++ version crash will generate a core dump.
Fix sonic-db-cli to avoid a core dump file generated.

#### How I did it
Catch all exception in sonic-db-cli to avoid core dump generated.

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix sonic-db-cli to avoid a core dump file generated.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

