### PR TITLE
Fix common path issue in profileprovider.cpp

### DIFF
--- a/common/profileprovider.h
+++ b/common/profileprovider.h
@@ -3,9 +3,9 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "common/table.h"
-#include "common/dbconnector.h"
-#include "common/converter.h"
+#include "table.h"
+#include "dbconnector.h"
+#include "converter.h"
 
 namespace swss {
 


### PR DESCRIPTION
#### Why I did it
sonic-gnmi will break if any header file contains 'common' in path

#### How I did it
Fix common path issue in profileprovider.cpp

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix common path issue in profileprovider.cpp

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

