### PR TITLE
Improve unit test for go wrapper

### DIFF
--- a/goext/Makefile
+++ b/goext/Makefile
@@ -1,5 +1,5 @@
 export CGO_LDFLAGS := -lswsscommon -lhiredis
-export CGO_CXXFLAGS := -I../ -I../common/ -w -Wall -fpermissive
+export CGO_CXXFLAGS := -I/usr/include/swss/ -w -Wall -fpermissive
 
 GO ?= /usr/local/go/bin/go
 SWIG ?= /usr/bin/swig
@@ -17,6 +17,7 @@ all:
 	$(SWIG) $(SWIG_FLAG) -I/usr/include/swss/ swsscommon.i
 
 check:
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) build
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test
 
 clean:


### PR DESCRIPTION
#### Why I did it
sonic-gnmi will break if any header file contains 'common' in path

#### How I did it
Improve unit test to detect common path issue

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Improve unit test to detect common path issue

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

