### PR TITLE
Add ZMQ config helper

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -66,6 +66,7 @@ common_libswsscommon_la_SOURCES = \
     common/redisutility.cpp          \
     common/restart_waiter.cpp        \
     common/profileprovider.cpp       \
+    common/zmqconfighelper.cpp       \
     common/redis_table_waiter.cpp
 
 common_libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS) $(CODE_COVERAGE_CXXFLAGS)

--- a/common/zmqconfighelper.cpp
+++ b/common/zmqconfighelper.cpp
@@ -1,0 +1,39 @@
+#include <string>
+#include <fstream>
+#include <system_error>
+#include <cerrno>
+#include <cstring>
+
+#include "zmqconfighelper.h"
+#include "json.hpp"
+#include "logger.h"
+
+using namespace std;
+using namespace nlohmann;
+
+namespace swss {
+
+int ZmqConfigHelper::GetSocketPort(string db, string tableName, std::string configPath)
+{
+    ifstream ifs(configPath);
+    if (!ifs.good())
+    {
+        SWSS_LOG_ERROR("failed to read '%s', err: %s", configPath.c_str(), strerror(errno));
+        throw system_error(make_error_code(errc::no_such_file_or_directory), "Failed to read config file");
+    }
+
+    try
+    {
+        json config;
+        ifs >> config;
+        json& item = config[db][tableName];
+        return item[ZMQ_PORT_CONFIG_NAME];
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Failed to find ZMQ socket port for database: %s, table: %s, error: %s", db.c_str(), tableName.c_str(), e.what());
+        throw e;
+    }
+}
+
+}

--- a/common/zmqconfighelper.h
+++ b/common/zmqconfighelper.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include "json.hpp"
+
+#define ZMQ_PORT_MAPPING_FILE           "/etc/sonic/zmp_port_mapping.json" 
+#define ZMQ_PORT_CONFIG_NAME            "port" 
+
+namespace swss {
+
+class ZmqConfigHelper
+{
+public:
+    static int GetSocketPort(std::string db, std::string tableName, std::string configPath = ZMQ_PORT_MAPPING_FILE);
+};
+
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,6 +39,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/restart_waiter_ut.cpp       \
                       tests/redis_table_waiter_ut.cpp   \
                       tests/profileprovider_ut.cpp      \
+                      tests/zmqconfighelper_ut.cpp      \
                       tests/main.cpp
 
 tests_tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/zmqconfig/zmp_port_mapping.json
+++ b/tests/zmqconfig/zmp_port_mapping.json
@@ -1,0 +1,7 @@
+{
+    "TEST_DB" : {
+        "TEST_TABLE" : {
+            "port" : 1234
+        }
+    }
+}

--- a/tests/zmqconfighelper_ut.cpp
+++ b/tests/zmqconfighelper_ut.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include "gtest/gtest.h"
+#include "common/zmqconfighelper.h"
+
+using namespace std;
+using namespace swss;
+
+static const string testAppName = "TestApp";
+static const string testDockerName = "TestDocker";
+
+TEST(ZmqConfigHelper, configNotExist)
+{
+    bool exception_happen = false;
+    try
+    {
+        ZmqConfigHelper::GetSocketPort("TEST_DB", "TEST_TABLE", "NotExistFile");
+    }
+    catch (const exception& e)
+    {
+        exception_happen = true;
+    }
+
+    EXPECT_EQ(true, exception_happen);
+}
+
+TEST(ZmqConfigHelper, getSocketPort)
+{
+    auto port = ZmqConfigHelper::GetSocketPort("TEST_DB", "TEST_TABLE", "./tests/zmqconfig/zmp_port_mapping.json");
+    EXPECT_EQ(1234, port);
+}
+
+
+TEST(ZmqConfigHelper, getSocketPortFailed)
+{
+    bool exception_happen = false;
+    try
+    {
+        ZmqConfigHelper::GetSocketPort("TEST_DB", "TEST_TABLE_NO_CONFIG", "./tests/zmqconfig/zmp_port_mapping.json");
+    }
+    catch (const exception& e)
+    {
+        exception_happen = true;
+    }
+
+    EXPECT_EQ(true, exception_happen);
+}


### PR DESCRIPTION
#### Why I did it
The ZMQ producer/consumer state table will initialize in different process with same port, so need a config file to config the DB/Table to ZMQ port mapping.

#### How I did it
Add ZmqConfigHelper class, the config file will check-in to sonic-buildimage repo.

#### How to verify it
Add new UT to cover ZmqConfigHelper.
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add ZMQ based ProducerStateTable and CustomerStateTable.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

