### PR TITLE
[logger] Add public `restartLogger` to restart logger thread

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -166,6 +166,11 @@ void Logger::linkToDbNative(const std::string& dbName, const char * defPrio)
     getInstance().restartSettingThread();
 }
 
+void Logger::restartLogger()
+{
+    getInstance().restartSettingThread();
+}
+
 Logger& Logger::getInstance()
 {
     static Logger m_logger;

--- a/common/logger.h
+++ b/common/logger.h
@@ -91,6 +91,7 @@ public:
     static void linkToDb(const std::string& dbName, const PriorityChangeNotify& notify, const std::string& defPrio);
     // Must be called after all linkToDb to start select from DB
     static void linkToDbNative(const std::string& dbName, const char * defPrio="NOTICE");
+    static void restartLogger();
     void write(Priority prio, const char *fmt, ...)
 #ifdef __GNUC__
         __attribute__ ((format (printf, 3, 4)))

--- a/tests/logger_ut.cpp
+++ b/tests/logger_ut.cpp
@@ -72,3 +72,26 @@ TEST(LOGGER, loglevel)
 
     cout << "Done." << endl;
 }
+
+TEST(LOGGER, CustomLogObserver)
+{
+    DBConnector db("CONFIG_DB", 0);
+    clearConfigDB();
+
+    string key1 = "table1";
+    Logger::linkToDb(key1, prioNotify, "NOTICE");
+    Logger::restartLogger();
+
+    sleep(1);
+
+    cout << "Checking log level for table1." << endl;
+    checkLoglevel(db, key1, "NOTICE");
+
+    cout << "Setting log level for table1." << endl;
+    setLoglevel(db, key1, "DEBUG");
+
+    sleep(1);
+
+    cout << "Checking log level for table1." << endl;
+    checkLoglevel(db, key1, "DEBUG");
+}


### PR DESCRIPTION
This is to support adding custom observers to the swss logger.
With `restartLogger`, now applications could start logger with the following lines:
```
linkToDb(demoDb, myCustomPrioNotify, defaultPrio);
restartLogger()
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>