### PR TITLE
Fix mod_config with empty config will delete table bug.

### DIFF
--- a/common/configdb.h
+++ b/common/configdb.h
@@ -198,9 +198,14 @@ protected:
         def mod_config(self, data):
             raw_config = {}
             for table_name, table_data in data.items():
-                raw_config[table_name] = {}
                 if table_data == None:
+                    # When table data is 'None', delete the table.
+                    raw_config[table_name] = {}
                     continue
+                if table_data == {}:
+                    # When table data is {}, no action.
+                    continue
+                raw_config[table_name] = {}
                 for key, data in table_data.items():
                     raw_key = self.serialize_key(key)
                     raw_data = self.typed_to_raw(data)

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -198,14 +198,13 @@ protected:
         def mod_config(self, data):
             raw_config = {}
             for table_name, table_data in data.items():
-                if table_data == None:
-                    # When table data is 'None', delete the table.
-                    raw_config[table_name] = {}
-                    continue
                 if table_data == {}:
                     # When table data is {}, no action.
                     continue
                 raw_config[table_name] = {}
+                if table_data == None:
+                    # When table data is 'None', delete the table.
+                    continue
                 for key, data in table_data.items():
                     raw_key = self.serialize_key(key)
                     raw_data = self.typed_to_raw(data)


### PR DESCRIPTION
#### Why I did it
Fix mod_config with empty config will delete table bug.

#### How I did it
Fix mod_config with empty config will delete table bug:
When config is None, delete table.
When config is empty, no action.

#### How to verify it
Add new UT to cover mod_config wity None and empty config case.
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix mod_config with empty config will delete table bug.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

