### PR TITLE
Fix python3 version detection in makefile.

### DIFF
--- a/m4/python3.m4
+++ b/m4/python3.m4
@@ -84,7 +84,7 @@ AC_DEFUN([AM_PATH_PYTHON3],
   dnl library.
 
   AC_CACHE_CHECK([for $am_display_PYTHON3 version], [am_cv_python3_version],
-    [am_cv_python3_version=`$PYTHON3 -c "import sys; sys.stdout.write(sys.version[[:3]])"`])
+    [am_cv_python3_version=`$PYTHON3 -c "import sys; print ('%u.%u' % sys.version_info[[:2]])"`])
   AC_SUBST([PYTHON3_VERSION], [$am_cv_python3_version])
 
   dnl Use the values of $prefix and $exec_prefix for the corresponding


### PR DESCRIPTION
# Problem

I am using python 3.10 on my dev machine and hitting the build error below, due to incorrect version being detected and it is trying to look for Python.h in /usr/include/python3.1 instead of /usr/include/python3.10.

```
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -std=c++11 -Icommon -I/usr/include/python3.1 -O0 -g -MT pyext/py3/pyext_py3__swsscommon_la-swsscommon_wrap.lo -MD -MP -MF pyext/py3/.deps/pyext_py3__swsscommon_la-swsscommon_wrap.Tpo -c pyext/py3/swsscommon_wrap.cpp  -fPIC -DPIC -o pyext/py3/.libs/pyext_py3__swsscommon_la-swsscommon_wrap.o
pyext/py3/swsscommon_wrap.cpp:173:11: fatal error: Python.h: No such file or directory
  173 | # include <Python.h>
      |           ^~~~~~~~~~
```

The reason is because we are using `sys.stdout.write(sys.version[[:3]])` to detect the version, which cut off the version to only 3 characters, hence 3.10 becomes 3.1.

```
checking for python3... /usr/bin/python3
checking for python3 version... 3.1
```

# Fix

The proposal is use the version_info instead of version, so we won't miss any characters, like below.

```
$ python3 -c "import sys; print ('%u.%u' % sys.version_info[:2])"
3.10
```