### PR TITLE
Add .dirstamp and generated sonic-db-cli into .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 Makefile.in
 stamp-h1
+.dirstamp
 **/.deps/
 **/.libs/
 **/Makefile
@@ -61,6 +62,7 @@ stamp-h1
 ###############
 common/swssloglevel
 tests/tests
+sonic-db-cli/sonic-db-cli
 
 # Bazel Build System #
 /bazel-*


### PR DESCRIPTION
# Problem

After build there are a few generated files from automake and libtool not excluded in the .gitignore.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        common/.dirstamp
        pyext/py2/.dirstamp
        pyext/py3/.dirstamp
        sonic-db-cli/.dirstamp
        sonic-db-cli/sonic-db-cli
        tests/.dirstamp
```

# Fix

Adding these files into .gitignore in order to avoid accidentally adding them into PR later.