### PR TITLE
Create directory /var/run/sswsyncd and add capability for syncd unittest

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -87,6 +87,7 @@ jobs:
       sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
       sudo sed -ri 's/^databases .*/databases 17/' /etc/redis/redis.conf
       sudo service redis-server start
+      sudo mkdir -m 755 /var/run/sswsyncd
 
       sudo apt-get install -y rsyslog
       sudo service rsyslog start
@@ -129,6 +130,8 @@ jobs:
       DEB_BUILD_OPTIONS=nocheck DEB_BUILD_PROFILES=nopython2 fakeroot dpkg-buildpackage -b -us -uc -Tbinary-syncd-vs -j$(nproc)
       # Add SYS_TIME capability for settimeofday ok in syncd test
       sudo setcap "cap_sys_time=eip" syncd/.libs/syncd_tests
+      # Add CAP_DAC_OVERRIDE capability for system directory creation in syncd unittest
+      sudo setcap "cap_dac_override,cap_ipc_lock,cap_ipc_owner,cap_sys_time=eip" unittest/syncd/.libs/tests
       make check
       mv ../*.deb .
     displayName: "Compile sonic sairedis"


### PR DESCRIPTION
sonic-swss-common/.azure-pipelines/build-sairedis-template.yml requires similar changes as what sonic-sairedis PR# 1230 has introduced in sonic-sairedis/.azure-pipelines/build-template.yml