### PR TITLE
Upgrade docker-py version to fix vstest failed issue.

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -48,7 +48,7 @@ jobs:
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan
       sudo apt-get install -y python3-pip
-      sudo pip3 install pytest==4.6.2 attrs==19.1.0 exabgp==4.0.10 distro==1.5.0 docker==4.4.1 redis==3.3.4 flaky==3.7.0
+      sudo pip3 install pytest==4.6.2 attrs==19.1.0 exabgp==4.0.10 distro==1.5.0 docker==6.1.0 redis==3.3.4 flaky==3.7.0
     displayName: "Install dependencies"
 
   - script: |


### PR DESCRIPTION
#### Why I did it
Currently vstest failed with following error:
2023-05-08T08:31:23.3230095Z 	<class 'docker.errors.DockerException'>
2023-05-08T08:31:23.3230364Z 	Error while fetching server API version: request() got an unexpected keyword argument 'chunked'

#### How I did it
Upgrade docker-py to 6.1.0

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Upgrade docker-py version to fix vstest failed issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

