### PR TITLE
Fix ZMQ UT timeout issue.

### DIFF
--- a/tests/zmq_state_ut.cpp
+++ b/tests/zmq_state_ut.cpp
@@ -20,7 +20,7 @@ using namespace swss;
 
 #define TEST_DB           "APPL_DB" // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
 #define NUMBER_OF_THREADS    (5) // Spawning more than 256 threads causes libc++ to except
-#define NUMBER_OF_OPS        (10)
+#define NUMBER_OF_OPS        (100)
 #define MAX_FIELDS       10 // Testing up to 30 fields objects
 #define PRINT_SKIP           (10) // Print + for Producer and - for Consumer for every 100 ops
 #define MAX_KEYS             (10)       // Testing up to 30 keys objects
@@ -51,6 +51,8 @@ static inline int readNumberAtEOL(const string& str)
     EXPECT_TRUE((bool)is);
     return ret;
 }
+
+static bool allDataReceived = false;
 
 static void producerWorker(string tableName, string endpoint)
 {
@@ -105,6 +107,11 @@ static void producerWorker(string tableName, string endpoint)
         }
 
         p.del(keys);
+    }
+
+    while (!allDataReceived)
+    {
+        sleep(1);
     }
 
     cout << "Producer thread ended: " << tableName << endl;
@@ -172,6 +179,7 @@ static void consumerWorker(string tableName, string endpoint)
         }
     }
 
+    allDataReceived = true;
     cout << "Consumer thread ended: " << tableName << endl;
 }
 

--- a/tests/zmq_state_ut.cpp
+++ b/tests/zmq_state_ut.cpp
@@ -20,7 +20,7 @@ using namespace swss;
 
 #define TEST_DB           "APPL_DB" // Need to test against a DB which uses a colon table name separator due to hardcoding in consumer_table_pops.lua
 #define NUMBER_OF_THREADS    (5) // Spawning more than 256 threads causes libc++ to except
-#define NUMBER_OF_OPS        (100)
+#define NUMBER_OF_OPS        (10)
 #define MAX_FIELDS       10 // Testing up to 30 fields objects
 #define PRINT_SKIP           (10) // Print + for Producer and - for Consumer for every 100 ops
 #define MAX_KEYS             (10)       // Testing up to 30 keys objects


### PR DESCRIPTION
Fix ZMQ UT timeout issue

#### Why I did it
ZMQ UT timeout, because UT code bug: before consumer thread receive all data, producer been released so some data never been send. so consumer wait for data untill timeout.

#### How I did it
Improve code, exit producer after consumer receive all data.

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix ZMQ UT timeout issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

