### PR TITLE
docker prefer COPY to ADD in dockerfile

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -2,6 +2,6 @@ FROM docker-sonic-vs
 
 ARG docker_container_name
 
-ADD ["debs", "/debs"]
+COPY ["debs", "/debs"]
 
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb /debs/python3-swsscommon_1.0.0_amd64.deb /debs/sonic-db-cli_1.0.0_amd64.deb /debs/libsaimetadata_1.0.0_amd64.deb /debs/libsairedis_1.0.0_amd64.deb /debs/libsaivs_1.0.0_amd64.deb /debs/syncd-vs_1.0.0_amd64.deb /debs/swss_1.0.0_amd64.deb


### PR DESCRIPTION
#### Why I did it
Docker best practices prefer COPY to ADD
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
##### Work item tracking
- Microsoft ADO **(number only)**: 17418730
#### How I did it
Use the COPY command as opposed to ADD unless working with a tar file.