### PR TITLE
 Improve go language SWIG wrapper: add exception mapping and enable directors feature.

### DIFF
--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -1,4 +1,9 @@
+#ifdef SWIGGO
+// Enable directors feature for go language to generate inheritance information
+%module(directors="1") swsscommon
+#else
 %module swsscommon
+#endif
 
 %rename(delete) del;
 
@@ -54,6 +59,7 @@
 %include <std_vector.i>
 %include <std_pair.i>
 %include <std_map.i>
+%include <std_deque.i>
 #ifdef SWIGPYTHON
 %include <std_shared_ptr.i>
 #endif
@@ -70,6 +76,7 @@
 %template(GetTableResult) std::map<std::string, std::map<std::string, std::string>>;
 %template(GetConfigResult) std::map<std::string, std::map<std::string, std::map<std::string, std::string>>>;
 %template(GetInstanceListResult) std::map<std::string, swss::RedisInstInfo>;
+%template(KeyOpFieldsValuesQueue) std::deque<std::tuple<std::string, std::string, std::vector<std::pair<std::string, std::string>>>>;
 
 #ifdef SWIGPYTHON
 %exception {
@@ -146,6 +153,28 @@
 }
 #endif
 
+#ifdef SWIGGO
+// Mapping c++ exception to go language panic
+%exception {
+	try {
+		$function
+	} catch(const std::system_error& e) {
+        if (e.code() == std::make_error_code(std::errc::connection_reset))
+        {
+		    SWIG_exception(SWIG_SystemError, "connection_reset");
+        }
+        else
+        {
+		    SWIG_exception(SWIG_SystemError, e.what());
+        }
+	} catch(std::exception &e) {
+		SWIG_exception(SWIG_RuntimeError,e.what());
+	} catch(...) {
+		SWIG_exception(SWIG_RuntimeError,"Unknown exception");
+	}
+}
+#endif
+
 %inline %{
 template <typename T>
 T castSelectableObj(swss::Selectable *temp)
@@ -179,7 +208,6 @@ T castSelectableObj(swss::Selectable *temp)
 %include "zmqserver.h"
 %include "zmqclient.h"
 %include "zmqconsumerstatetable.h"
-%include "zmqproducerstatetable.h"
 
 %extend swss::DBConnector {
     %template(hgetall) hgetall<std::map<std::string, std::string>>;
@@ -211,7 +239,15 @@ T castSelectableObj(swss::Selectable *temp)
 %clear std::vector<std::pair<std::string, std::string>> &values;
 
 %include "producertable.h"
+
+#ifdef SWIGGO
+// Generate inheritance information for ProducerStateTable and ZmqProducerStateTable
+%feature("director") swss::ProducerStateTable;
+%feature("director") swss::ZmqProducerStateTable;
+#endif
+
 %include "producerstatetable.h"
+%include "zmqproducerstatetable.h"
 
 %apply std::string& OUTPUT {std::string &key};
 %apply std::string& OUTPUT {std::string &op};


### PR DESCRIPTION
 Improve go language SWIG wrapper: add exception mapping and enable directors feature.

#### Work item tracking
Microsoft ADO (number only): 24117097

#### Why I did it
Go language not support c++ exception.
Class inheritance information missing in go wrapper.

#### How I did it
Add exception handler to mapping c++ exception to go panic.
Enable directors feature to convert c++ class inheritance information to go wrapper class inheritance information.

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
 Improve go language SWIG wrapper: add exception mapping and enable directors feature.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

