### PR TITLE
Add ZMQ port for orchagent

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -508,6 +508,10 @@ namespace swss {
 
 #define PROFILE_DELETE_TABLE                  "PROFILE_DELETE"
 
+/***** ZMQ ADDRESS *****/
+
+#define DASH_ORCH_ZMQ_ADDRESS                 "tcp://*:1234"
+
 /***** MISC *****/
 
 #define IPV4_NAME "IPv4"

--- a/common/schema.h
+++ b/common/schema.h
@@ -508,10 +508,6 @@ namespace swss {
 
 #define PROFILE_DELETE_TABLE                  "PROFILE_DELETE"
 
-/***** ZMQ ADDRESS *****/
-
-#define DASH_ORCH_ZMQ_ADDRESS                 "tcp://*:1234"
-
 /***** MISC *****/
 
 #define IPV4_NAME "IPv4"

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -12,7 +12,7 @@
 #define MQ_WATERMARK 10000
 
 /***** ZMQ PORT *****/
-static const DASH_ORCH_ZMQ_PORT                8020
+static const ORCH_ZMQ_PORT                8020
 
 namespace swss {
 

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -11,6 +11,9 @@
 #define MQ_POLL_TIMEOUT (1000)
 #define MQ_WATERMARK 10000
 
+/***** ZMQ ADDRESS *****/
+#define DASH_ORCH_ZMQ_ADDRESS                 "tcp://*:1234"
+
 namespace swss {
 
 class ZmqMessageHandler

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -12,7 +12,7 @@
 #define MQ_WATERMARK 10000
 
 /***** ZMQ PORT *****/
-static const ORCH_ZMQ_PORT                8020
+static const int ORCH_ZMQ_PORT = 8020;
 
 namespace swss {
 

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -11,8 +11,8 @@
 #define MQ_POLL_TIMEOUT (1000)
 #define MQ_WATERMARK 10000
 
-/***** ZMQ ADDRESS *****/
-#define DASH_ORCH_ZMQ_ADDRESS                 "tcp://*:1234"
+/***** ZMQ PORT *****/
+#define DASH_ORCH_ZMQ_PORT                 1234
 
 namespace swss {
 

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -12,7 +12,7 @@
 #define MQ_WATERMARK 10000
 
 /***** ZMQ PORT *****/
-#define DASH_ORCH_ZMQ_PORT                 1234
+static const DASH_ORCH_ZMQ_PORT                8020
 
 namespace swss {
 


### PR DESCRIPTION
Add ZMQ port for orchagent.

#### Work item tracking
Microsoft ADO (number only): 17753804

#### Why I did it
Orchagent need create ZMQ server for listen incoming connection.

#### How I did it
Add ZMQ address to zmqserver.h

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add ZMQ port for orchagent.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

