### PR TITLE
Add batch support in ZmqProducerStateTable.

### DIFF
--- a/common/asyncdbupdater.h
+++ b/common/asyncdbupdater.h
@@ -6,7 +6,6 @@
 #include "dbconnector.h"
 #include "table.h"
 
-#define MQ_RESPONSE_MAX_COUNT (4*1024*1024)
 #define MQ_SIZE 100
 #define MQ_MAX_RETRY 10
 #define MQ_POLL_TIMEOUT (1000)

--- a/common/zmqclient.cpp
+++ b/common/zmqclient.cpp
@@ -103,21 +103,24 @@ void ZmqClient::connect()
 }
 
 void ZmqClient::sendMsg(
-        const std::string& key,
-        const std::vector<swss::FieldValueTuple>& values,
-        const std::string& command,
         const std::string& dbName,
         const std::string& tableName,
+        const std::vector<KeyOpFieldsValuesTuple>& kcos,
         std::vector<char>& sendbuffer)
 {
     int serializedlen = (int)BinarySerializer::serializeBuffer(
                                                         sendbuffer.data(),
                                                         sendbuffer.size(),
-                                                        key,
-                                                        values,
-                                                        command,
                                                         dbName,
-                                                        tableName);
+                                                        tableName,
+                                                        kcos);
+
+    if (serializedlen >= MQ_RESPONSE_MAX_COUNT)
+    {
+        SWSS_LOG_THROW("ZmqClient sendMsg message was too big (buffer size %d bytes, got %d), reduce the message size, message DROPPED",
+                MQ_RESPONSE_MAX_COUNT,
+                serializedlen);
+    }
 
     SWSS_LOG_DEBUG("sending: %d", serializedlen);
     int zmq_err = 0;

--- a/common/zmqclient.h
+++ b/common/zmqclient.h
@@ -19,11 +19,9 @@ public:
 
     void connect();
 
-    void sendMsg(const std::string& key,
-                 const std::vector<swss::FieldValueTuple>& values,
-                 const std::string& command,
-                 const std::string& dbName,
+    void sendMsg(const std::string& dbName,
                  const std::string& tableName,
+                 const std::vector<KeyOpFieldsValuesTuple>& kcos,
                  std::vector<char>& sendbuffer);
 private:
     void initialize(const std::string& endpoint);

--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -70,7 +70,7 @@ public:
     size_t dbUpdaterQueueSize();
 
 private:
-    void handleReceivedData(std::shared_ptr<KeyOpFieldsValuesTuple> pkco);
+    void handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos);
 
     std::mutex m_receivedQueueMutex;
 

--- a/common/zmqproducerstatetable.h
+++ b/common/zmqproducerstatetable.h
@@ -34,6 +34,9 @@ public:
 
     virtual void del(const std::vector<std::string> &keys);
 
+    // Batched send that can include both SET and DEL requests.
+    virtual void send(const std::vector<KeyOpFieldsValuesTuple> &kcos);
+
     size_t dbUpdaterQueueSize();
 private:
     void initialize(DBConnector *db, const std::string &tableName, bool dbPersistence);

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -3,9 +3,10 @@
 #include <string>
 #include <deque>
 #include <condition_variable>
+#include <vector>
 #include "table.h"
 
-#define MQ_RESPONSE_MAX_COUNT (4*1024*1024)
+#define MQ_RESPONSE_MAX_COUNT (16*1024*1024)
 #define MQ_SIZE 100
 #define MQ_MAX_RETRY 10
 #define MQ_POLL_TIMEOUT (1000)
@@ -20,7 +21,7 @@ class ZmqMessageHandler
 {
 public:
     virtual ~ZmqMessageHandler() {};
-    virtual void handleReceivedData(std::shared_ptr<KeyOpFieldsValuesTuple> pkco) = 0;
+    virtual void handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos) = 0;
 };
 
 class ZmqServer
@@ -43,6 +44,8 @@ private:
     void mqPollThread();
     
     ZmqMessageHandler* findMessageHandler(const std::string dbName, const std::string tableName);
+
+    std::vector<char> m_buffer;
 
     volatile bool m_runThread;
 

--- a/tests/zmq_state_ut.cpp
+++ b/tests/zmq_state_ut.cpp
@@ -127,6 +127,74 @@ static void producerWorker(string tableName, string endpoint, bool dbPersistence
     cout << "Producer thread ended: " << tableName << endl;
 }
 
+// Reusing the same keys as the producerWorker so that the same consumer thread
+// can be used.
+static void producerBatchWorker(string tableName, string endpoint, bool dbPersistence)
+{
+    DBConnector db(TEST_DB, 0, true);
+    ZmqClient client(endpoint);
+    ZmqProducerStateTable p(&db, tableName, client, dbPersistence);
+    cout << "Producer thread started: " << tableName << endl;
+    std::vector<KeyOpFieldsValuesTuple> kcos;
+
+    for (int i = 0; i < NUMBER_OF_OPS; i++)
+    {
+        vector<FieldValueTuple> fields;
+        for (int j = 0; j < MAX_FIELDS; j++)
+        {
+            FieldValueTuple t(field(j), value(j));
+            fields.push_back(t);
+        }
+        kcos.push_back(KeyOpFieldsValuesTuple("set_key_" + to_string(i), SET_COMMAND, fields));
+    }
+
+    for (int i = 0; i < NUMBER_OF_OPS; i++)
+    {
+        kcos.push_back(KeyOpFieldsValuesTuple("del_key_" + to_string(i), DEL_COMMAND, vector<FieldValueTuple>{}));
+    }
+
+    for (int i = 0; i < NUMBER_OF_OPS; i++)
+    {
+        for (int j = 0; j < MAX_KEYS; j++)
+        {
+            vector<FieldValueTuple> fields;
+            for (int k = 0; k < MAX_FIELDS; k++)
+            {
+                FieldValueTuple t(field(k), value(k));
+                fields.push_back(t);
+            }
+            kcos.push_back(KeyOpFieldsValuesTuple("batch_set_key_" + to_string(i) + "_" + to_string(j), SET_COMMAND, fields));
+        }
+    }
+
+    for (int i = 0; i < NUMBER_OF_OPS; i++)
+    {
+        for (int j = 0; j < MAX_KEYS; j++)
+        {
+            kcos.push_back(KeyOpFieldsValuesTuple("batch_del_key_" + to_string(i) + "_" + to_string(j), DEL_COMMAND, vector<FieldValueTuple>{}));
+        }
+    }
+
+    p.send(kcos);
+
+    // wait all data been received by consumer
+    while (!allDataReceived)
+    {
+        sleep(1);
+    }
+
+    if (dbPersistence)
+    {
+        // wait all persist data write to redis
+        while (p.dbUpdaterQueueSize() > 0)
+        {
+            sleep(1);
+        }
+    }
+
+    cout << "Producer thread ended: " << tableName << endl;
+}
+
 // variable used by consumer worker
 static int setCount = 0;
 static int delCount = 0;
@@ -203,7 +271,6 @@ static void consumerWorker(string tableName, string endpoint, bool dbPersistence
     cout << "Consumer thread ended: " << tableName << endl;
 }
 
-
 static void testMethod(bool producerPersistence)
 {
     std::string testTableName = "ZMQ_PROD_CONS_UT";
@@ -263,6 +330,69 @@ static void testMethod(bool producerPersistence)
     }
     EXPECT_EQ(setCount, NUMBER_OF_OPS);
     EXPECT_EQ(batchSetCount, NUMBER_OF_OPS * MAX_KEYS);
+
+    cout << endl << "Done." << endl;
+}
+
+static void testBatchMethod(bool producerPersistence)
+{
+    std::string testTableName = "ZMQ_PROD_CONS_UT";
+    std::string pushEndpoint = "tcp://localhost:1234";
+    std::string pullEndpoint = "tcp://*:1234";
+    thread *producerThreads[NUMBER_OF_THREADS];
+
+    // reset receive data counter
+    setCount = 0;
+    delCount = 0;
+    batchSetCount = 0;
+    batchDelCount = 0;
+    allDataReceived = false;
+
+    // start consumer first, SHM can only have 1 consumer per table.
+    thread *consumerThread = new thread(consumerWorker, testTableName, pullEndpoint, !producerPersistence);
+
+    cout << "Starting " << NUMBER_OF_THREADS << " producers" << endl;
+    /* Starting the producer before the producer */
+    for (int i = 0; i < NUMBER_OF_THREADS; i++)
+    {
+        producerThreads[i] = new thread(producerBatchWorker, testTableName, pushEndpoint, producerPersistence);
+    }
+
+    cout << "Done. Waiting for all job to finish " << NUMBER_OF_OPS << " jobs." << endl;
+    for (int i = 0; i < NUMBER_OF_THREADS; i++)
+    {
+        producerThreads[i]->join();
+        delete producerThreads[i];
+    }
+
+    consumerThread->join();
+    delete consumerThread;
+
+    EXPECT_EQ(setCount, NUMBER_OF_THREADS * NUMBER_OF_OPS);
+    EXPECT_EQ(delCount, NUMBER_OF_THREADS * NUMBER_OF_OPS);
+    EXPECT_EQ(batchSetCount, NUMBER_OF_THREADS * NUMBER_OF_OPS * MAX_KEYS);
+    EXPECT_EQ(batchDelCount, NUMBER_OF_THREADS * NUMBER_OF_OPS * MAX_KEYS);
+
+    // check presist data in redis
+    DBConnector db(TEST_DB, 0, true);
+    Table table(&db, testTableName);
+    std::vector<std::string> keys;
+    table.getKeys(keys);
+    setCount = 0;
+    batchSetCount = 0;
+    for (string& key : keys)
+    {
+        if (key.rfind("batch_set_key_", 0) == 0)
+        {
+            batchSetCount++;
+        }
+        else if (key.rfind("set_key_", 0) == 0)
+        {
+            setCount++;
+        }
+    }
+    EXPECT_EQ(setCount, NUMBER_OF_OPS);
+    EXPECT_EQ(batchSetCount, NUMBER_OF_OPS * MAX_KEYS);
     
     cout << endl << "Done." << endl;
 }
@@ -273,9 +403,38 @@ TEST(ZmqConsumerStateTable, test)
     testMethod(false);
 }
 
-
 TEST(ZmqProducerStateTable, test)
 {
     // test with persist by producer
     testMethod(true);
+}
+
+TEST(ZmqConsumerStateTableBatch, test)
+{
+    // test with persist by consumer
+    testBatchMethod(false);
+}
+
+TEST(ZmqProducerStateTableBatch, test)
+{
+    // test with persist by producer
+    testBatchMethod(true);
+}
+
+TEST(ZmqConsumerStateTableBatchBufferOverflow, test)
+{
+    std::string testTableName = "ZMQ_PROD_CONS_UT";
+    std::string pushEndpoint = "tcp://localhost:1234";
+
+    DBConnector db(TEST_DB, 0, true);
+    ZmqClient client(pushEndpoint);
+    ZmqProducerStateTable p(&db, testTableName, client, true);
+
+    // Send a large message and expect exception thrown.
+    std::vector<KeyOpFieldsValuesTuple> kcos;
+    for (int i = 0; i <= MQ_RESPONSE_MAX_COUNT; i++)
+    {
+        kcos.push_back(KeyOpFieldsValuesTuple("key", DEL_COMMAND, vector<FieldValueTuple>{}));
+    }
+    EXPECT_ANY_THROW(p.send(kcos));
 }


### PR DESCRIPTION
The existing batch implementation in ZmqProducerStateTable only calls the individual API repeatedly. This change brings in the real batch implementation:
1. Add a new method in ZmqProducerStateTable, send(), which can batch both SET and DEL operations in a single call.
2. Update the BinarySerializer to encode multiple SET & DEL requests in a single message. The new encoding format is the following:

* db name
* table name
* key1
* number of attrs in key1
* field
* value
* ...
* key2
* number of attrs in key2
* field
* value
* ...

3. Increase ZMQ buffer size from 4MB to 16MB.
