### PR TITLE
Revert "Fix the issue of ignoring callback calls for removed keys. (#789)"

### DIFF
--- a/common/configdb.h
+++ b/common/configdb.h
@@ -120,7 +120,7 @@ protected:
         ## Dynamic typed functions used in python
         @staticmethod
         def raw_to_typed(raw_data):
-            if not raw_data or not raw_data.keys():
+            if raw_data is None:
                 return None
             typed_data = {}
             for raw_key in raw_data:

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -634,29 +634,20 @@ def test_ConfigDBSubscribe():
 def test_ConfigDBInit():
     table_name_1 = 'TEST_TABLE_1'
     table_name_2 = 'TEST_TABLE_2'
-    table_name_3 = 'TEST_TABLE_3'
     test_key = 'key1'
     test_data = {'field1': 'value1'}
-
-    queue = multiprocessing.Queue()
+    test_data_update = {'field1': 'value2'}
 
     manager = multiprocessing.Manager()
     ret_data = manager.dict()
 
-    def test_handler(table, key, data, ret, q=None):
-        if data is None:
-            ret[table] = {k: v for k, v in ret[table].items() if k != key}
-        else:
-            ret[table] = {key: data}
+    def test_handler(table, key, data, ret):
+        ret[table] = {key: data}
 
-        if q:
-            q.put(ret[table])
-
-    def test_init_handler(data, ret, queue):
+    def test_init_handler(data, ret):
         ret.update(data)
-        queue.put(ret)
 
-    def thread_listen(ret, queue):
+    def thread_listen(ret):
         config_db = ConfigDBConnector()
         config_db.connect(wait_for_init=False)
 
@@ -664,10 +655,8 @@ def test_ConfigDBInit():
                             fire_init_data=False)
         config_db.subscribe(table_name_2, lambda table, key, data: test_handler(table, key, data, ret),
                             fire_init_data=True)
-        config_db.subscribe(table_name_3, lambda table, key, data: test_handler(table, key, data, ret, queue),
-                            fire_init_data=False)
 
-        config_db.listen(init_data_handler=lambda data: test_init_handler(data, ret, queue))
+        config_db.listen(init_data_handler=lambda data: test_init_handler(data, ret))
 
     config_db = ConfigDBConnector()
     config_db.connect(wait_for_init=False)
@@ -677,26 +666,14 @@ def test_ConfigDBInit():
     # Init table data
     config_db.set_entry(table_name_1, test_key, test_data)
     config_db.set_entry(table_name_2, test_key, test_data)
-    config_db.set_entry(table_name_3, test_key, {})
 
-    thread = multiprocessing.Process(target=thread_listen, args=(ret_data, queue))
+    thread = multiprocessing.Process(target=thread_listen, args=(ret_data,))
     thread.start()
-
-    init_data = queue.get(5)
-
-    # Verify that all tables initialized correctly
-    assert init_data[table_name_1] == {test_key: test_data}
-    assert init_data[table_name_2] == {test_key: test_data}
-    assert init_data[table_name_3] == {test_key: {}}
-
-    # Remove the entry (with no attributes) from the table.
-    # Verify that the update is received and a callback is called
-    config_db.set_entry(table_name_3, test_key, None)
-
-    table_3_data = queue.get(5)
-    assert test_key not in table_3_data
-
+    time.sleep(5)
     thread.terminate()
+
+    assert ret_data[table_name_1] == {test_key: test_data}
+    assert ret_data[table_name_2] == {test_key: test_data}
 
 
 def test_DBConnectFailure():


### PR DESCRIPTION
This reverts commit e0f394cd44370370e872711b04a15e497b63e0f8.

The reason is unexpected behavior change of `get_entry`. ref: https://github.com/sonic-net/sonic-swss-common/pull/789#issuecomment-1639525084