### PR TITLE
Fix syncd crashing due to invalid length being used for string printing

### DIFF
--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -130,7 +130,7 @@ int RedisCommand::appendTo(redisContext *ctx) const
 
 std::string RedisCommand::toPrintableString() const
 {
-    return binary_to_printable(temp, len);
+    return binary_to_printable(temp, length());
 }
 
 const char *RedisCommand::c_str() const


### PR DESCRIPTION
PR #801 added some code to convert binary strings to be printable strings. However, one code path used the raw value of `len` without sanity checking as the length of the string, when the `length()` function should have been used instead.

Sample syncd backtrace:

```
#0  0x00007fddc635fce1 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007fddc6349537 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007fddc65af7ec in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007fddc65ba966 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007fddc65ba9d1 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007fddc65bac65 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007fddc65b209a in std::__throw_length_error(char const*) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007fddc664849c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_create(unsigned long&, unsigned long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007fddc6648cfc in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::reserve(unsigned long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007fddc6daad6c in swss::binary_to_printable (buffer=0x55feeaced250, length=18446744073354011680) at common/stringutility.h:172
#10 0x00007fddc6dac41c in swss::RedisCommand::toPrintableString[abi:cxx11]() const (this=0x7ffc0af84500) at common/rediscommand.cpp:133
#11 0x00007fddc6d195b1 in swss::RedisReply::RedisReply (this=0x7ffc0af84508, ctx=0x55feeace8ca0, command=...) at common/redisreply.cpp:94
#12 0x00007fddc6d19bab in swss::RedisReply::RedisReply (this=0x7ffc0af84508, ctx=0x55feeace8ca0, command=..., expectedType=1) at common/redisreply.cpp:116
#13 0x000055fee92c9dcd in syncd::RedisClient::RedisClient(std::shared_ptr<swss::DBConnector>) ()
#14 0x000055fee9280681 in syncd::Syncd::Syncd(std::shared_ptr<sairedis::SaiInterface>, std::shared_ptr<syncd::CommandLineOptions>, bool) ()
#15 0x000055fee92697ed in syncd_main(int, char**) ()
#16 0x000055fee9267b8f in main ()

#10 0x00007fddc6dac41c in swss::RedisCommand::toPrintableString[abi:cxx11]() const (this=0x7ffc0af84500) at common/rediscommand.cpp:133
133     common/rediscommand.cpp: No such file or directory.
(gdb) print *this
$22 = {temp = 0x55feeaced250 "*3\r\n$6\r\nSCRIPT\r\n$4\r\nLOAD\r\n$863\r\nlocal keys = redis.call('KEYS', KEYS[1])\nlocal n = table.getn(keys)\n\nfor i = 1, n do\n   if KEYS[2] == \"\" and KEYS[3] == \"1\" then\n      redis.call('DEL', keys[i])  \n   e"..., len = -355539936}
```

Fix this by using the `length()` function.