### PR TITLE
Fix binary serializer can't deserialize protopuf buffer content issue.

### DIFF
--- a/common/binaryserializer.h
+++ b/common/binaryserializer.h
@@ -3,6 +3,8 @@
 
 #include "common/armhelper.h"
 
+using namespace std;
+
 namespace swss {
 
 class BinarySerializer {
@@ -64,7 +66,7 @@ public:
                                                                                             size);
             }
 
-            auto pkey = tmp_buffer;
+            auto pkey = string(tmp_buffer, *pkeylen);
             tmp_buffer += *pkeylen;
 
             WARNINGS_NO_CAST_ALIGN;
@@ -79,7 +81,7 @@ public:
                                                                                             size);
             }
             
-            auto pval = tmp_buffer;
+            auto pval = string(tmp_buffer, *pvallen);
             tmp_buffer += *pvallen;
 
             values.push_back(std::make_pair(pkey, pval));
@@ -107,9 +109,8 @@ private:
     void setKeyAndValue(const char* key, size_t klen,
                         const char* value, size_t vlen)
     {
-        // to improve deserialize performance, copy null-terminated string. 
-        setData(key, klen + 1);
-        setData(value, vlen + 1);
+        setData(key, klen);
+        setData(value, vlen);
 
         m_kvp_count++;
     }

--- a/tests/binary_serializer_ut.cpp
+++ b/tests/binary_serializer_ut.cpp
@@ -29,7 +29,7 @@ TEST(BinarySerializer, serialize_deserialize)
                                                                 test_table);
     string serialized_str(buffer);
 
-    EXPECT_EQ(serialized_len, 107);
+    EXPECT_EQ(serialized_len, 101);
 
     auto ptr = std::make_shared<KeyOpFieldsValuesTuple>();
     KeyOpFieldsValuesTuple &kco = *ptr;
@@ -83,4 +83,49 @@ TEST(BinarySerializer, deserialize_overflow)
     KeyOpFieldsValuesTuple &kco = *ptr;
     auto& deserialized_values = kfvFieldsValues(kco);
     EXPECT_THROW(BinarySerializer::deserializeBuffer(buffer, serialized_len - 10, deserialized_values), runtime_error);
+}
+
+TEST(BinarySerializer, protocol_buffer)
+{
+    string test_entry_key = "test_key";
+    string test_command = "test_command";
+    string test_db = "test_db";
+    string test_table = "test_table";
+    string test_key = "key";
+    unsigned char binary_proto_buf[] = {0x0a, 0x05, 0x0d, 0x0a, 0x01, 0x00, 0x20, 0x10, 0xe1, 0x21};
+    string proto_buf_val = string((const char *)binary_proto_buf, sizeof(binary_proto_buf));
+    EXPECT_TRUE(proto_buf_val.length() == sizeof(binary_proto_buf));
+
+    char buffer[200];
+    std::vector<FieldValueTuple> values;
+    values.push_back(std::make_pair(test_key, proto_buf_val));
+    int serialized_len = (int)BinarySerializer::serializeBuffer(
+                                                                buffer,
+                                                                sizeof(buffer),
+                                                                test_entry_key,
+                                                                values,
+                                                                test_command,
+                                                                test_db,
+                                                                test_table);
+    string serialized_str(buffer);
+
+    EXPECT_EQ(serialized_len, 106);
+
+    auto ptr = std::make_shared<KeyOpFieldsValuesTuple>();
+    KeyOpFieldsValuesTuple &kco = *ptr;
+    auto& deserialized_values = kfvFieldsValues(kco);
+    BinarySerializer::deserializeBuffer(buffer, serialized_len, deserialized_values);
+    
+    swss::FieldValueTuple fvt = deserialized_values.at(0);
+    EXPECT_TRUE(fvField(fvt) == test_db);
+    EXPECT_TRUE(fvValue(fvt) == test_table);
+
+    fvt = deserialized_values.at(1);
+    EXPECT_TRUE(fvField(fvt) == test_entry_key);
+    EXPECT_TRUE(fvValue(fvt) == test_command);
+
+    fvt = deserialized_values.at(2);
+    EXPECT_TRUE(fvField(fvt) == test_key);
+    EXPECT_TRUE(fvValue(fvt) == proto_buf_val);
+    EXPECT_TRUE(fvValue(fvt).length() == sizeof(binary_proto_buf));
 }


### PR DESCRIPTION
Fix binary serializer can't deserialize protopuf buffer content issue.

#### Work item tracking
Microsoft ADO (number only): 17753804

#### Why I did it
Fix binary serializer can't deserialize protopuf buffer content issue.

#### How I did it
Fix code but when deserialize binary string.

#### How to verify it
Add UT.
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix binary serializer can't deserialize protopuf buffer content issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

