### PR TITLE
[azp] Fix swss missing libs

### DIFF
--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -107,6 +107,10 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
         target/debs/${{ parameters.debian_version }}/libyang-*.deb
         target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
+        target/debs/${{ parameters.debian_version }}/libprotoc*.deb
+        target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb
+        target/debs/${{ parameters.debian_version }}/libdashapi*.deb
     displayName: "Download common libs"
 
   - script: |

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -6,6 +6,10 @@ parameters:
 - name: log_artifact_name
   type: string
 
+- name: sonic_buildimage_ubuntu20_04
+  type: string
+  default: '$(BUILD_BRANCH)'
+
 jobs:
 - job:
   displayName: vstest
@@ -35,6 +39,16 @@ jobs:
       artifact: sonic-swss-common.amd64.ubuntu20_04
       path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download pre-stage built sonic-swss-common.amd64.ubuntu20_04"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: sonic-net.sonic-buildimage-ubuntu20.04
+      artifact: sonic-buildimage.amd64.ubuntu20_04
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.sonic_buildimage_ubuntu20_04 }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download sonic buildimage ubuntu20.04 deb packages"
 
   - script: |
       set -ex
@@ -42,6 +56,8 @@ jobs:
       sudo sonic-swss-common/.azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14 libyang0.16
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb
       sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 


### PR DESCRIPTION
Swss containter needs dash_api to properly build, based on https://github.com/sonic-net/sonic-swss/pull/2722, attempting to add missing libs