### PR TITLE
Address comments from PR 812: Add check before deserializing messages

### DIFF
--- a/common/events_common.h
+++ b/common/events_common.h
@@ -309,7 +309,7 @@ struct serialization
         more = 0;
         zmq_msg_init(&msg);
         int rc = zmq_msg_recv(&msg, sock, flag);
-	int msg_size = static_cast<int>(zmq_msg_size(&msg));
+        size_t msg_size = zmq_msg_size(&msg);
         if (rc != -1 && msg_size > 1) {
             size_t more_size = sizeof (more);
 

--- a/common/events_common.h
+++ b/common/events_common.h
@@ -258,9 +258,6 @@ struct serialization
     int
     deserialize(const string& s, Map& data)
     {
-        if (s.size() < 2) { // zmq identifying message of length 1
-            return 0;
-        }
         try {
             istringstream ss(s);
             boost::archive::text_iarchive iarch(ss);
@@ -312,7 +309,8 @@ struct serialization
         more = 0;
         zmq_msg_init(&msg);
         int rc = zmq_msg_recv(&msg, sock, flag);
-        if (rc != -1) {
+	int msg_size = static_cast<int>(zmq_msg_size(&msg));
+        if (rc != -1 && msg_size > 1) {
             size_t more_size = sizeof (more);
 
             zmq_getsockopt (sock, ZMQ_RCVMORE, &more, &more_size);

--- a/tests/events_common_ut.cpp
+++ b/tests/events_common_ut.cpp
@@ -81,19 +81,24 @@ TEST(events_common, send_recv)
     void *sock_p1 = zmq_socket (zmq_ctx, ZMQ_PAIR);
     EXPECT_EQ(0, zmq_bind (sock_p1, path));
 
-    string source("Hello"), source1, source2("#");
+    string source("Hello"), source1, source2, source3;
 
     map<string, string> m = {{"foo", "bar"}, {"hello", "world"}, {"good", "day"}};
-    map<string, string> m1, m2;
+    map<string, string> m1, m2, m3;
 
     EXPECT_EQ(0, zmq_message_send(sock_p0, source, m));
 
     EXPECT_EQ(0, zmq_message_read(sock_p1, 0, source1, m1));
-
+ 
     EXPECT_EQ(source, source1);
     EXPECT_EQ(m, m1);
+    
+    
+    EXPECT_EQ(0, zmq_message_send(sock_p0, source2, m2));
+    EXPECT_EQ(0, zmq_message_read(sock_p1, 0, source3, m3));
 
-    EXPECT_EQ(0, deserialize(source2, m2));
+    EXPECT_EQ(source2, source3);
+    EXPECT_EQ(m2, m3);
 
     zmq_close(sock_p0);
     zmq_close(sock_p1);

--- a/tests/events_common_ut.cpp
+++ b/tests/events_common_ut.cpp
@@ -89,7 +89,7 @@ TEST(events_common, send_recv)
     EXPECT_EQ(0, zmq_message_send(sock_p0, source, m));
 
     EXPECT_EQ(0, zmq_message_read(sock_p1, 0, source1, m1));
- 
+
     EXPECT_EQ(source, source1);
     EXPECT_EQ(m, m1);
     


### PR DESCRIPTION
Comment 1

@zbud-msft , I don't think the envelopes message is the root cause of bug #12570, because according to the document you past:

https://zguide.zeromq.org/docs/chapter3/
When you use REQ and REP sockets you don’t even see envelopes; these sockets deal with them automatically.

Do you have log or test case to show how ZMQ receive the "envelope delimiter" and pass it to deserializer?

The new code here is just ignore those short message, but as my understand the "envelope delimiter" should not never deserialize, you need add code in the socket receive code to ignore the delimiter there.

Response

After reviewing, I also realize that the envelope delimiter is not the RC for this issue. After reviewing the code, we realize that the message is a control character being read by zmg_msg_recv, which when displayed as c_str() is '001' and of length 1. I have opened an issue with libzmq about this issue, but will drop messages of length 1 and less for now https://github.com/zeromq/libzmq/issues/4587: 


Comment 2 

This new code in UT doesn't relate with ZMQ. the source2 not send/receive via ZMQ, why put it here?

I suggest you create a new UT:

1. send message via ZMQ
2. receiver socket add code to check and ignore "envelope delimiter"
3. In UT check the signal (the signal can be a log message) that the "envelope delimiter" been ignored and not cause error.

Response

Since we are not dealing with "envelope delimiter", I have created a UT where zmq socket sends messages with empty source and empty data