### PR TITLE
Fix swss-common binskim errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES =
 bin_PROGRAMS =
 
 if DEBUG
-DBGFLAGS = -ggdb -DDEBUG
+DBGFLAGS = -ggdb -DDEBUG -gdwarf-5
 else
 DBGFLAGS = -g -DNDEBUG
 endif

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -75,6 +75,7 @@ common_libswsscommon_la_SOURCES = \
 common_libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS) $(CODE_COVERAGE_CXXFLAGS)
 common_libswsscommon_la_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CPPFLAGS) $(CODE_COVERAGE_CPPFLAGS)
 common_libswsscommon_la_LIBADD = -lpthread $(LIBNL_LIBS) $(CODE_COVERAGE_LIBS) -lzmq -lboost_serialization -luuid -lyang
+common_libswsscommon_la_LDFLAGS = -Wl,-z,now $(LDFLAGS)
 
 common_swssloglevel_SOURCES =  \
 	common/loglevel.cpp        \
@@ -84,3 +85,4 @@ common_swssloglevel_SOURCES =  \
 common_swssloglevel_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
 common_swssloglevel_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CODE_COVERAGE_CPPFLAGS)
 common_swssloglevel_LDADD = common/libswsscommon.la $(CODE_COVERAGE_LIBS)
+common_swssloglevel_LDFLAGS = -Wl,-z,now $(LDFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,7 @@ CFLAGS_COMMON+=" -Wvariadic-macros"
 CFLAGS_COMMON+=" -Wno-write-strings"
 CFLAGS_COMMON+=" -Wno-missing-format-attribute"
 CFLAGS_COMMON+=" -Wno-long-long"
+CFLAGS_COMMON+=" -fstack-protector-strong"
 
 AC_SUBST(CFLAGS_COMMON)
 

--- a/pyext/py2/Makefile.am
+++ b/pyext/py2/Makefile.am
@@ -2,8 +2,8 @@ pkgpython_PYTHON = pyext/py2/swsscommon.py pyext/py2/__init__.py
 pkgpyexec_LTLIBRARIES = pyext/py2/_swsscommon.la
 
 pyext_py2__swsscommon_la_SOURCES = pyext/py2/swsscommon_wrap.cpp
-pyext_py2__swsscommon_la_CPPFLAGS = -std=c++11 -Icommon -I/usr/include/python$(PYTHON_VERSION)
-pyext_py2__swsscommon_la_LDFLAGS = -module
+pyext_py2__swsscommon_la_CPPFLAGS = -std=c++11 -Icommon -I/usr/include/python$(PYTHON_VERSION) -fstack-protector-strong
+pyext_py2__swsscommon_la_LDFLAGS = -module -Wl,-z,now
 pyext_py2__swsscommon_la_LIBADD = common/libswsscommon.la -lpython$(PYTHON_VERSION)
 
 pyext/py2/swsscommon_wrap.cpp: $(SWIG_SOURCES)

--- a/pyext/py3/Makefile.am
+++ b/pyext/py3/Makefile.am
@@ -2,8 +2,8 @@ pkgpython3_PYTHON = pyext/py3/swsscommon.py pyext/py3/__init__.py
 pkgpy3exec_LTLIBRARIES = pyext/py3/_swsscommon.la
 
 pyext_py3__swsscommon_la_SOURCES = pyext/py3/swsscommon_wrap.cpp
-pyext_py3__swsscommon_la_CPPFLAGS = -std=c++11 -Icommon -I/usr/include/python$(PYTHON3_VERSION)
-pyext_py3__swsscommon_la_LDFLAGS = -module
+pyext_py3__swsscommon_la_CPPFLAGS = -std=c++11 -Icommon -I/usr/include/python$(PYTHON3_VERSION) -fstack-protector-strong
+pyext_py3__swsscommon_la_LDFLAGS = -module -Wl,-z,now
 pyext_py3__swsscommon_la_LIBADD = common/libswsscommon.la $(PYTHON3_BLDLIBRARY)
 
 pyext/py3/swsscommon_wrap.cpp: $(SWIG_SOURCES)

--- a/sonic-db-cli/Makefile.am
+++ b/sonic-db-cli/Makefile.am
@@ -3,9 +3,11 @@ sonic_db_cli_libsonicdbcli_la_SOURCES = sonic-db-cli/sonic-db-cli.cpp
 sonic_db_cli_libsonicdbcli_la_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 sonic_db_cli_libsonicdbcli_la_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON)
 sonic_db_cli_libsonicdbcli_la_LIBADD = common/libswsscommon.la -lpthread
+sonic_db_cli_libsonicdbcli_la_LDFLAGS = -Wl,-z,now $(LDFLAGS)
 
 bin_PROGRAMS += sonic-db-cli/sonic-db-cli
 sonic_db_cli_sonic_db_cli_SOURCES = sonic-db-cli/sonic-db-cli.cpp sonic-db-cli/main.cpp
 sonic_db_cli_sonic_db_cli_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 sonic_db_cli_sonic_db_cli_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON)
 sonic_db_cli_sonic_db_cli_LDADD = common/libswsscommon.la -lpthread
+sonic_db_cli_sonic_db_cli_LDFLAGS = -Wl,-z,now $(LDFLAGS)


### PR DESCRIPTION
Fix swss-common binskim errors.

#### Work item tracking
Microsoft ADO (number only): 25090081

#### Why I did it
binskim scan report error BA3003, BA3004 and BA3011:

BA3003: The stack protector was not found. This may be because '--stack-protector-strong' was not used, or because it was explicitly disabled by '-fno-stack-protectors'.

BA3004: using debugging dwarf version '{1}'. The dwarf version 5 contains more information and should be used. To enable the debugging version 5 use '-gdwarf-5'.

BA3011: The BIND_NOW flag is missing from this binary, so relocation sections will not be marked as read only after the binary is loaded.  An attacker can overwrite these to redirect control flow.  Ensure you are compiling with the compiler flags '-Wl,-z,now' to address this.

#### How I did it
Add compiler flag and ld flag according to following document:

https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md

For BA3003, add '-fstack-protector-strong' to configure.ac, which will enable GCC strong stack protect feature.
For BA3011, add LD flag '-Wl,-z,now' to every make file, this is because azure pipeline will overwrite global LD flag defined in config.ac for code coverage.
For BA3004, add '-gdwarf-5' to makefile.am for debug build generate better debug information.

#### How to verify it
Pass all UT.

Manually verify issue fixed with following steps:
1. clone latest code from https://github.com/microsoft/binskim/tree/main
2. build by run 'BuildAndTest.cmd' command
3. Open this PR build aritfact, download all x86 debs and extract file to local device.
4. Run scan with following command and confirm issue fixed:
.\bld\bin\x64_Release\net6.0\BinSkim.exe analyze .\sonic-swss-common\usr\bin\*
.\bld\bin\x64_Release\net6.0\BinSkim.exe analyze .\sonic-swss-common\usr\lib\*

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix swss-common binskim errors.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

