### PR TITLE
Support async DB update for both ZMQ producer&consumer table.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -70,6 +70,7 @@ common_libswsscommon_la_SOURCES = \
     common/profileprovider.cpp       \
     common/zmqclient.cpp             \
     common/zmqserver.cpp             \
+    common/asyncdbupdater.cpp   \
     common/redis_table_waiter.cpp
 
 common_libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS) $(CODE_COVERAGE_CXXFLAGS)

--- a/common/asyncdbupdater.cpp
+++ b/common/asyncdbupdater.cpp
@@ -63,15 +63,13 @@ void AsyncDBUpdater::dbUpdateThread()
 
     while (m_runThread)
     {
-        m_dbUpdateDataNotifyCv.wait(cvLock);
-
         size_t count;
+        count = queueSize();
+        if (count == 0)
         {
-            count = queueSize();
-            if (!count)
-            {
-                continue;
-            }
+            // when queue is empty, wait notification, when data come, continue to check queue size again
+            m_dbUpdateDataNotifyCv.wait(cvLock);
+            continue;
         }
 
         for (size_t ie = 0; ie < count; ie++)
@@ -101,6 +99,8 @@ void AsyncDBUpdater::dbUpdateThread()
             }
         }
     }
+
+    SWSS_LOG_DEBUG("AsyncDBUpdater dbUpdateThread end: %s", m_tableName.c_str());
 }
 
 size_t AsyncDBUpdater::queueSize()

--- a/common/asyncdbupdater.cpp
+++ b/common/asyncdbupdater.cpp
@@ -1,0 +1,111 @@
+#include <string>
+#include <deque>
+#include <limits>
+#include <hiredis/hiredis.h>
+#include <pthread.h>
+#include "asyncdbupdater.h"
+#include "dbconnector.h"
+#include "redisselect.h"
+#include "redisapi.h"
+#include "table.h"
+
+using namespace std;
+
+namespace swss {
+
+AsyncDBUpdater::AsyncDBUpdater(DBConnector *db, const std::string &tableName)
+    : m_db(db)
+    , m_tableName(tableName)
+{
+    m_runThread = true;
+    m_dbUpdateThread = std::make_shared<std::thread>(&AsyncDBUpdater::dbUpdateThread, this);
+
+    SWSS_LOG_DEBUG("AsyncDBUpdater ctor tableName: %s", tableName.c_str());
+}
+
+AsyncDBUpdater::~AsyncDBUpdater()
+{
+    m_runThread = false;
+
+    // notify db update thread exit
+    m_dbUpdateDataNotifyCv.notify_all();
+    m_dbUpdateThread->join();
+}
+
+void AsyncDBUpdater::update(std::shared_ptr<KeyOpFieldsValuesTuple> pkco)
+{
+    {
+        std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
+        m_dbUpdateDataQueue.push(pkco);
+    }
+
+    m_dbUpdateDataNotifyCv.notify_all();
+}
+
+void AsyncDBUpdater::dbUpdateThread()
+{
+    SWSS_LOG_ENTER();
+    SWSS_LOG_NOTICE("dbUpdateThread begin");
+
+    // Different schedule policy has different min priority 
+    pthread_attr_t attr;
+    int policy;
+    pthread_attr_getschedpolicy(&attr, &policy);
+    int min_priority = sched_get_priority_min(policy);
+    // Use min priority will block poll thread 
+    pthread_setschedprio(pthread_self(), min_priority + 1);
+
+    // Follow same logic in ConsumerStateTable: every received data will write to 'table'.
+    DBConnector db(m_db->getDbName(), 0, true);
+    Table table(&db, m_tableName);
+    std::mutex cvMutex;
+    std::unique_lock<std::mutex> cvLock(cvMutex);
+
+    while (m_runThread)
+    {
+        m_dbUpdateDataNotifyCv.wait(cvLock);
+
+        size_t count;
+        {
+            // size() is not thread safe
+            std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
+ 
+            // For new data append to m_dataQueue during pops, will not be include in result.
+            count = m_dbUpdateDataQueue.size();
+            if (!count)
+            {
+                continue;
+            }
+
+        }
+
+        for (size_t ie = 0; ie < count; ie++)
+        {
+            auto& kco = *(m_dbUpdateDataQueue.front());
+
+            if (kfvOp(kco) == SET_COMMAND)
+            {
+                auto& values = kfvFieldsValues(kco);
+
+                // Delete entry before Table::set(), because Table::set() does not remove the no longer existed fields from entry.
+                table.del(kfvKey(kco));
+                table.set(kfvKey(kco), values);
+            }
+            else if (kfvOp(kco) == DEL_COMMAND)
+            {
+                table.del(kfvKey(kco));
+            }
+            else
+            {
+                SWSS_LOG_ERROR("db: %s, table: %s receive unknown operation: %s", m_db->getDbName().c_str(), m_tableName.c_str(), kfvOp(kco).c_str());
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
+                m_dbUpdateDataQueue.pop();
+            }
+        }
+    }
+}
+
+}

--- a/common/asyncdbupdater.cpp
+++ b/common/asyncdbupdater.cpp
@@ -67,16 +67,11 @@ void AsyncDBUpdater::dbUpdateThread()
 
         size_t count;
         {
-            // size() is not thread safe
-            std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
- 
-            // For new data append to m_dataQueue during pops, will not be include in result.
-            count = m_dbUpdateDataQueue.size();
+            count = queueSize();
             if (!count)
             {
                 continue;
             }
-
         }
 
         for (size_t ie = 0; ie < count; ie++)
@@ -106,6 +101,14 @@ void AsyncDBUpdater::dbUpdateThread()
             }
         }
     }
+}
+
+size_t AsyncDBUpdater::queueSize()
+{
+    // size() is not thread safe
+    std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
+
+    return m_dbUpdateDataQueue.size();
 }
 
 }

--- a/common/asyncdbupdater.h
+++ b/common/asyncdbupdater.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <deque>
+#include <condition_variable>
+#include "dbconnector.h"
+#include "table.h"
+
+#define MQ_RESPONSE_MAX_COUNT (4*1024*1024)
+#define MQ_SIZE 100
+#define MQ_MAX_RETRY 10
+#define MQ_POLL_TIMEOUT (1000)
+
+namespace swss {
+
+class AsyncDBUpdater
+{
+public:
+    AsyncDBUpdater(DBConnector *db, const std::string &tableName);
+    ~AsyncDBUpdater();
+
+    void update(std::shared_ptr<KeyOpFieldsValuesTuple> pkco);
+
+private:
+    void dbUpdateThread();
+
+    volatile bool m_runThread;
+
+    std::shared_ptr<std::thread> m_dbUpdateThread;
+
+    std::mutex m_dbUpdateDataQueueMutex;
+
+    std::condition_variable m_dbUpdateDataNotifyCv;
+
+    std::queue<std::shared_ptr<KeyOpFieldsValuesTuple>> m_dbUpdateDataQueue;
+
+    DBConnector *m_db;
+
+    std::string m_tableName;
+};
+
+}

--- a/common/asyncdbupdater.h
+++ b/common/asyncdbupdater.h
@@ -21,6 +21,7 @@ public:
 
     void update(std::shared_ptr<KeyOpFieldsValuesTuple> pkco);
 
+    size_t queueSize();
 private:
     void dbUpdateThread();
 

--- a/common/zmqconsumerstatetable.cpp
+++ b/common/zmqconsumerstatetable.cpp
@@ -90,4 +90,14 @@ void ZmqConsumerStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const
     }
 }
 
+size_t ZmqConsumerStateTable::dbUpdaterQueueSize()
+{
+    if (m_asyncDBUpdater == nullptr)
+    {
+        return 0;
+    }
+
+    return m_asyncDBUpdater->queueSize();
+}
+
 }

--- a/common/zmqconsumerstatetable.cpp
+++ b/common/zmqconsumerstatetable.cpp
@@ -26,13 +26,12 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
     if (dbPersistence)
     {
         SWSS_LOG_DEBUG("Database persistence enabled, tableName: %s", tableName.c_str());
-        m_runThread = true;
-        m_dbUpdateThread = std::make_shared<std::thread>(&ZmqConsumerStateTable::dbUpdateThread, this);
+        m_asyncDBUpdater = std::make_unique<AsyncDBUpdater>(db, tableName);
     }
     else
     {
         SWSS_LOG_DEBUG("Database persistence disabled, tableName: %s", tableName.c_str());
-        m_dbUpdateThread = nullptr;
+        m_asyncDBUpdater = nullptr;
     }
 
     m_zmqServer.registerMessageHandler(m_db->getDbName(), tableName, this);
@@ -40,22 +39,10 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
     SWSS_LOG_DEBUG("ZmqConsumerStateTable ctor tableName: %s", tableName.c_str());
 }
 
-ZmqConsumerStateTable::~ZmqConsumerStateTable()
-{
-    if (m_dbUpdateThread != nullptr)
-    {
-        m_runThread = false;
-
-        // notify db update thread exit
-        m_dbUpdateDataNotifyCv.notify_all();
-        m_dbUpdateThread->join();
-    }
-}
-
 void ZmqConsumerStateTable::handleReceivedData(std::shared_ptr<KeyOpFieldsValuesTuple> pkco)
 {
     std::shared_ptr<KeyOpFieldsValuesTuple> clone = nullptr;
-    if (m_dbUpdateThread != nullptr)
+    if (m_asyncDBUpdater != nullptr)
     {
         // clone before put to received queue, because received data may change by consumer.
         clone = std::make_shared<KeyOpFieldsValuesTuple>(*pkco);
@@ -68,80 +55,9 @@ void ZmqConsumerStateTable::handleReceivedData(std::shared_ptr<KeyOpFieldsValues
 
     m_selectableEvent.notify(); // will release epoll
 
-    if (m_dbUpdateThread != nullptr)
+    if (m_asyncDBUpdater != nullptr)
     {
-        {
-            std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
-            m_dbUpdateDataQueue.push(clone);
-        }
-
-        m_dbUpdateDataNotifyCv.notify_all();
-    }
-}
-
-void ZmqConsumerStateTable::dbUpdateThread()
-{
-    SWSS_LOG_ENTER();
-    SWSS_LOG_NOTICE("dbUpdateThread begin");
-
-    // Different schedule policy has different min priority 
-    pthread_attr_t attr;
-    int policy;
-    pthread_attr_getschedpolicy(&attr, &policy);
-    int min_priority = sched_get_priority_min(policy);
-    // Use min priority will block poll thread 
-    pthread_setschedprio(pthread_self(), min_priority + 1);
-
-    // Follow same logic in ConsumerStateTable: every received data will write to 'table'.
-    DBConnector db(m_db->getDbName(), 0, true);
-    Table table(&db, getTableName());
-    std::mutex cvMutex;
-    std::unique_lock<std::mutex> cvLock(cvMutex);
-
-    while (m_runThread)
-    {
-        m_dbUpdateDataNotifyCv.wait(cvLock);
-
-        size_t count;
-        {
-            // size() is not thread safe
-            std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
- 
-            // For new data append to m_dataQueue during pops, will not be include in result.
-            count = m_dbUpdateDataQueue.size();
-            if (!count)
-            {
-                continue;
-            }
-
-        }
-
-        for (size_t ie = 0; ie < count; ie++)
-        {
-            auto& kco = *(m_dbUpdateDataQueue.front());
-
-            if (kfvOp(kco) == SET_COMMAND)
-            {
-                auto& values = kfvFieldsValues(kco);
-
-                // Delete entry before Table::set(), because Table::set() does not remove the no longer existed fields from entry.
-                table.del(kfvKey(kco));
-                table.set(kfvKey(kco), values);
-            }
-            else if (kfvOp(kco) == DEL_COMMAND)
-            {
-                table.del(kfvKey(kco));
-            }
-            else
-            {
-                SWSS_LOG_ERROR("zmq consumer table: %s, receive unknown operation: %s", getTableName().c_str(), kfvOp(kco).c_str());
-            }
-
-            {
-                std::lock_guard<std::mutex> lock(m_dbUpdateDataQueueMutex);
-                m_dbUpdateDataQueue.pop();
-            }
-        }
+        m_asyncDBUpdater->update(clone);
     }
 }
 

--- a/common/zmqconsumerstatetable.cpp
+++ b/common/zmqconsumerstatetable.cpp
@@ -94,7 +94,8 @@ size_t ZmqConsumerStateTable::dbUpdaterQueueSize()
 {
     if (m_asyncDBUpdater == nullptr)
     {
-        return 0;
+        throw system_error(make_error_code(errc::operation_not_supported),
+                           "Database persistence is not enabled");
     }
 
     return m_asyncDBUpdater->queueSize();

--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -3,10 +3,11 @@
 #include <string>
 #include <deque>
 #include <condition_variable>
-#include "dbconnector.h"
-#include "table.h"
+#include "asyncdbupdater.h"
 #include "consumertablebase.h"
+#include "dbconnector.h"
 #include "selectableevent.h"
+#include "table.h"
 #include "zmqserver.h"
 
 #define MQ_RESPONSE_MAX_COUNT (4*1024*1024)
@@ -22,8 +23,7 @@ public:
     /* The default value of pop batch size is 128 */
     static constexpr int DEFAULT_POP_BATCH_SIZE = 128;
 
-    ZmqConsumerStateTable(DBConnector *db, const std::string &tableName, ZmqServer &zmqServer, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0, bool dbPersistence = true);
-    ~ZmqConsumerStateTable();
+    ZmqConsumerStateTable(DBConnector *db, const std::string &tableName, ZmqServer &zmqServer, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0, bool dbPersistence = false);
 
     /* Get multiple pop elements */
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);
@@ -75,27 +75,17 @@ public:
 private:
     void handleReceivedData(std::shared_ptr<KeyOpFieldsValuesTuple> pkco);
 
-    void dbUpdateThread();
-
-    volatile bool m_runThread;
-
     std::mutex m_receivedQueueMutex;
 
     std::queue<std::shared_ptr<KeyOpFieldsValuesTuple>> m_receivedOperationQueue;
 
     swss::SelectableEvent m_selectableEvent;
 
-    std::shared_ptr<std::thread> m_dbUpdateThread;
-
-    std::mutex m_dbUpdateDataQueueMutex;
-
-    std::condition_variable m_dbUpdateDataNotifyCv;
-
-    std::queue<std::shared_ptr<KeyOpFieldsValuesTuple>> m_dbUpdateDataQueue;
-
     DBConnector *m_db;
 
     ZmqServer& m_zmqServer;
+
+    std::unique_ptr<AsyncDBUpdater> m_asyncDBUpdater;
 };
 
 }

--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -10,11 +10,6 @@
 #include "table.h"
 #include "zmqserver.h"
 
-#define MQ_RESPONSE_MAX_COUNT (4*1024*1024)
-#define MQ_SIZE 100
-#define MQ_MAX_RETRY 10
-#define MQ_POLL_TIMEOUT (1000)
-
 namespace swss {
 
 class ZmqConsumerStateTable : public Selectable, public TableBase, public ZmqMessageHandler

--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -72,6 +72,8 @@ public:
         return m_db;
     }
 
+    size_t dbUpdaterQueueSize();
+
 private:
     void handleReceivedData(std::shared_ptr<KeyOpFieldsValuesTuple> pkco);
 

--- a/common/zmqproducerstatetable.cpp
+++ b/common/zmqproducerstatetable.cpp
@@ -155,4 +155,14 @@ void ZmqProducerStateTable::del(const std::vector<std::string> &keys)
     }
 }
 
+size_t ZmqProducerStateTable::dbUpdaterQueueSize()
+{
+    if (m_asyncDBUpdater == nullptr)
+    {
+        return 0;
+    }
+
+    return m_asyncDBUpdater->queueSize();
+}
+
 }

--- a/common/zmqproducerstatetable.cpp
+++ b/common/zmqproducerstatetable.cpp
@@ -18,27 +18,38 @@ using namespace std;
 
 namespace swss {
 
-ZmqProducerStateTable::ZmqProducerStateTable(DBConnector *db, const string &tableName, ZmqClient &zmqClient)
+ZmqProducerStateTable::ZmqProducerStateTable(DBConnector *db, const string &tableName, ZmqClient &zmqClient, bool dbPersistence)
     : ProducerStateTable(db, tableName),
     m_zmqClient(zmqClient),
     m_dbName(db->getDbName()),
     m_tableNameStr(tableName)
 {
-    initialize();
+    initialize(db, tableName, dbPersistence);
 }
 
-ZmqProducerStateTable::ZmqProducerStateTable(RedisPipeline *pipeline, const string &tableName, ZmqClient &zmqClient, bool buffered)
+ZmqProducerStateTable::ZmqProducerStateTable(RedisPipeline *pipeline, const string &tableName, ZmqClient &zmqClient, bool buffered, bool dbPersistence)
     : ProducerStateTable(pipeline, tableName, buffered),
     m_zmqClient(zmqClient),
     m_dbName(pipeline->getDbName()),
     m_tableNameStr(tableName)
 {
-    initialize();
+    initialize(pipeline->getDBConnector(), tableName, dbPersistence);
 }
 
-void ZmqProducerStateTable::initialize()
+void ZmqProducerStateTable::initialize(DBConnector *db, const std::string &tableName, bool dbPersistence)
 {
     m_sendbuffer.resize(MQ_RESPONSE_MAX_COUNT);
+    
+    if (dbPersistence)
+    {
+        SWSS_LOG_DEBUG("Database persistence enabled, tableName: %s", tableName.c_str());
+        m_asyncDBUpdater = std::make_unique<AsyncDBUpdater>(db, tableName);
+    }
+    else
+    {
+        SWSS_LOG_DEBUG("Database persistence disabled, tableName: %s", tableName.c_str());
+        m_asyncDBUpdater = nullptr;
+    }
 }
 
 void ZmqProducerStateTable::set(
@@ -54,6 +65,20 @@ void ZmqProducerStateTable::set(
                         m_dbName,
                         m_tableNameStr,
                         m_sendbuffer);
+
+    if (m_asyncDBUpdater != nullptr)
+    {
+        // async write need keep data till write to DB
+        std::shared_ptr<KeyOpFieldsValuesTuple> clone = std::make_shared<KeyOpFieldsValuesTuple>();
+        kfvKey(*clone) = key;
+        kfvOp(*clone) = op;
+        for(const auto &value : values)
+        {
+            kfvFieldsValues(*clone).push_back(value);
+        }
+
+        m_asyncDBUpdater->update(clone);
+    }
 }
 
 void ZmqProducerStateTable::del(
@@ -68,16 +93,39 @@ void ZmqProducerStateTable::del(
                         m_dbName,
                         m_tableNameStr,
                         m_sendbuffer);
+
+    if (m_asyncDBUpdater != nullptr)
+    {
+        // async write need keep data till write to DB
+        std::shared_ptr<KeyOpFieldsValuesTuple> clone = std::make_shared<KeyOpFieldsValuesTuple>();
+        kfvKey(*clone) = key;
+        kfvOp(*clone) = op;
+
+        m_asyncDBUpdater->update(clone);
+    }
 }
 
 void ZmqProducerStateTable::set(const std::vector<KeyOpFieldsValuesTuple> &values)
 {
     for (const auto &value : values)
     {
-        set(
-            kfvKey(value),
-            kfvFieldsValues(value),
-            SET_COMMAND);
+        m_zmqClient.sendMsg(
+                            kfvKey(value),
+                            kfvFieldsValues(value),
+                            SET_COMMAND,
+                            m_dbName,
+                            m_tableNameStr,
+                            m_sendbuffer);
+    }
+    
+    if (m_asyncDBUpdater != nullptr)
+    {
+        for (const auto &value : values)
+        {
+            // async write need keep data till write to DB
+            std::shared_ptr<KeyOpFieldsValuesTuple> clone = std::make_shared<KeyOpFieldsValuesTuple>(value);
+            m_asyncDBUpdater->update(clone);
+        }
     }
 }
 
@@ -85,7 +133,25 @@ void ZmqProducerStateTable::del(const std::vector<std::string> &keys)
 {
     for (const auto &key : keys)
     {
-        del(key, DEL_COMMAND);
+        m_zmqClient.sendMsg(
+                            key,
+                            vector<FieldValueTuple>(),
+                            DEL_COMMAND,
+                            m_dbName,
+                            m_tableNameStr,
+                            m_sendbuffer);
+    }
+    
+    if (m_asyncDBUpdater != nullptr)
+    {
+        for (const auto &key : keys)
+        {
+            // async write need keep data till write to DB
+            std::shared_ptr<KeyOpFieldsValuesTuple> clone = std::make_shared<KeyOpFieldsValuesTuple>();
+            kfvKey(*clone) = key;
+            kfvOp(*clone) = DEL_COMMAND;
+            m_asyncDBUpdater->update(clone);
+        }
     }
 }
 

--- a/common/zmqproducerstatetable.cpp
+++ b/common/zmqproducerstatetable.cpp
@@ -159,7 +159,8 @@ size_t ZmqProducerStateTable::dbUpdaterQueueSize()
 {
     if (m_asyncDBUpdater == nullptr)
     {
-        return 0;
+        throw system_error(make_error_code(errc::operation_not_supported),
+                           "Database persistence is not enabled");
     }
 
     return m_asyncDBUpdater->queueSize();

--- a/common/zmqproducerstatetable.h
+++ b/common/zmqproducerstatetable.h
@@ -34,6 +34,7 @@ public:
 
     virtual void del(const std::vector<std::string> &keys);
 
+    size_t dbUpdaterQueueSize();
 private:
     void initialize(DBConnector *db, const std::string &tableName, bool dbPersistence);
 

--- a/common/zmqproducerstatetable.h
+++ b/common/zmqproducerstatetable.h
@@ -5,9 +5,10 @@
 #include <queue>
 #include <thread> 
 #include <mutex> 
-#include "table.h"
-#include "redispipeline.h"
+#include "asyncdbupdater.h"
 #include "producerstatetable.h"
+#include "redispipeline.h"
+#include "table.h"
 #include "zmqclient.h"
 
 namespace swss {
@@ -15,8 +16,8 @@ namespace swss {
 class ZmqProducerStateTable : public ProducerStateTable
 {
 public:
-    ZmqProducerStateTable(DBConnector *db, const std::string &tableName, ZmqClient &zmqClient);
-    ZmqProducerStateTable(RedisPipeline *pipeline, const std::string &tableName, ZmqClient &zmqClient, bool buffered = false);
+    ZmqProducerStateTable(DBConnector *db, const std::string &tableName, ZmqClient &zmqClient, bool dbPersistence = true);
+    ZmqProducerStateTable(RedisPipeline *pipeline, const std::string &tableName, ZmqClient &zmqClient, bool buffered = false, bool dbPersistence = true);
 
     /* Implements set() and del() commands using notification messages */
     virtual void set(const std::string &key,
@@ -34,7 +35,7 @@ public:
     virtual void del(const std::vector<std::string> &keys);
 
 private:
-    void initialize();
+    void initialize(DBConnector *db, const std::string &tableName, bool dbPersistence);
 
     ZmqClient& m_zmqClient;
     
@@ -42,6 +43,8 @@ private:
 
     const std::string m_dbName;
     const std::string m_tableNameStr;
+
+    std::unique_ptr<AsyncDBUpdater> m_asyncDBUpdater;
 };
 
 }

--- a/tests/zmq_state_ut.cpp
+++ b/tests/zmq_state_ut.cpp
@@ -58,7 +58,7 @@ static void producerWorker(string tableName, string endpoint, bool dbPersistence
 {
     DBConnector db(TEST_DB, 0, true);
     ZmqClient client(endpoint);
-    ZmqProducerStateTable p(&db, tableName, client, false);
+    ZmqProducerStateTable p(&db, tableName, client, dbPersistence);
     cout << "Producer thread started: " << tableName << endl;
 
     for (int i = 0; i < NUMBER_OF_OPS; i++)
@@ -129,7 +129,7 @@ static void consumerWorker(string tableName, string endpoint, bool dbPersistence
     
     DBConnector db(TEST_DB, 0, true);
     ZmqServer server(endpoint);
-    ZmqConsumerStateTable c(&db, tableName, server);
+    ZmqConsumerStateTable c(&db, tableName, server, dbPersistence);
     Select cs;
     cs.addSelectable(&c);
 


### PR DESCRIPTION
#### Why I did it
Some scenarios require sonic-gnmi side update data to APPL_DB.

#### How I did it
Move async DB update code to AsyncDBUpdater.
Reuse AsyncDBUpdater in both ZmqProducerStateTable and ZmqConsumerStateTable

#### How to verify it
Pass all UT and E2E test cases.
Add new UT.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Support async DB update for both ZMQ producer&consumer table.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

