### PR TITLE
Add STATE_TRANSCEIVER_INFO_TABLE_NAME to shcema.h

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -507,6 +507,8 @@ namespace swss {
 
 #define STATE_VNET_MONITOR_TABLE_NAME          "VNET_MONITOR_TABLE"
 
+#define STATE_TRANSCEIVER_INFO_TABLE_NAME           "TRANSCEIVER_INFO"
+
 // ACL table and ACL rule table
 #define STATE_ACL_TABLE_TABLE_NAME                  "ACL_TABLE_TABLE"
 #define STATE_ACL_RULE_TABLE_NAME                   "ACL_RULE_TABLE"


### PR DESCRIPTION
in order to have the host_tx_ready enhancements, the table name is added to schema.h.

HLD: https://github.com/sonic-net/SONiC/pull/1453