### PR TITLE
Inspur keep del when del set sequence exist

### DIFF
--- a/common/consumer_state_table_pops.lua
+++ b/common/consumer_state_table_pops.lua
@@ -6,16 +6,20 @@ local keys = redis.call('SPOP', KEYS[1], ARGV[1])
 local n = table.getn(keys)
 for i = 1, n do
    local key = keys[i]
+   local fieldvalues = {}
    -- Check if there was request to delete the key, clear it in table first
    local num = redis.call('SREM', KEYS[3], key)
    if num == 1 then
       redis.call('DEL', tablename..key)
+      table.insert(ret, {key, fieldvalues})
    end
    -- Push the new set of field/value for this key in table
    local fieldvalues = redis.call('HGETALL', stateprefix..tablename..key)
-   table.insert(ret, {key, fieldvalues})
-   for i = 1, #fieldvalues, 2 do
-      redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
+   if table.getn(fieldvalues) > 0 then
+      table.insert(ret, {key, fieldvalues})
+      for i = 1, #fieldvalues, 2 do
+         redis.call('HSET', tablename..key, fieldvalues[i], fieldvalues[i + 1])
+      end
    end
    -- Clean up the key in temporary state table
    redis.call('DEL', stateprefix..tablename..key)

--- a/tests/redis_piped_state_ut.cpp
+++ b/tests/redis_piped_state_ut.cpp
@@ -328,9 +328,16 @@ TEST(ConsumerStateTable, async_set_del_set)
         KeyOpFieldsValuesTuple kco;
         c.pop(kco);
         EXPECT_EQ(kfvKey(kco), key);
-        EXPECT_EQ(kfvOp(kco), "SET");
+        EXPECT_EQ(kfvOp(kco), "DEL");
 
         auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), 0U);
+
+        c.pop(kco);
+        EXPECT_EQ(kfvKey(kco), key);
+        EXPECT_EQ(kfvOp(kco), "SET");
+
+        fvs = kfvFieldsValues(kco);
         EXPECT_EQ(fvs.size(), (unsigned int)maxNumOfFields);
 
         map<string, string> mm;

--- a/tests/redis_state_ut.cpp
+++ b/tests/redis_state_ut.cpp
@@ -344,9 +344,16 @@ TEST(ConsumerStateTable, set_del_set)
         KeyOpFieldsValuesTuple kco;
         c.pop(kco);
         EXPECT_EQ(kfvKey(kco), key);
-        EXPECT_EQ(kfvOp(kco), "SET");
+        EXPECT_EQ(kfvOp(kco), "DEL");
 
         auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), 0U);
+
+        c.pop(kco);
+        EXPECT_EQ(kfvKey(kco), key);
+        EXPECT_EQ(kfvOp(kco), "SET");
+
+        fvs = kfvFieldsValues(kco);
         EXPECT_EQ(fvs.size(), (unsigned int)maxNumOfFields);
 
         map<string, string> mm;
@@ -451,9 +458,16 @@ TEST(ConsumerStateTable, set_pop_del_set_pop_get)
         KeyOpFieldsValuesTuple kco;
         c.pop(kco);
         EXPECT_EQ(kfvKey(kco), key);
-        EXPECT_EQ(kfvOp(kco), "SET");
+        EXPECT_EQ(kfvOp(kco), "DEL");
 
         auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), 0U);
+
+        c.pop(kco);
+        EXPECT_EQ(kfvKey(kco), key);
+        EXPECT_EQ(kfvOp(kco), "SET");
+
+        fvs = kfvFieldsValues(kco);
 
         /* size of fvs should be maxNumOfFields, no "field 1" left from first set*/
         EXPECT_EQ(fvs.size(), (unsigned int)maxNumOfFields);


### PR DESCRIPTION
 Why I did it:
     when set after delete in a short time, consumer state may lost the del event.
     then what the multimap bring us for it may lost still.
 What I do:
     add the delete event even set after
     and modify the ut test for these changes.
     this can be verified by these testcase.