### PR TITLE
Add SonicDBConfig::reset method

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -185,6 +185,18 @@ void SonicDBConfig::initialize(const string &file)
     m_init = true;
 }
 
+// This API is used to uninitialize the SonicDBConfig class.
+// And then user can call initialize with different config file.
+void SonicDBConfig::uninitialize()
+{
+    std::lock_guard<std::recursive_mutex> guard(m_db_info_mutex);
+    m_init = false;
+    m_global_init = false;
+    m_inst_info.clear();
+    m_db_info.clear();
+    m_db_separator.clear();
+}
+
 void SonicDBConfig::validateNamespace(const string &netns)
 {
     std::lock_guard<std::recursive_mutex> guard(m_db_info_mutex);

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -185,9 +185,9 @@ void SonicDBConfig::initialize(const string &file)
     m_init = true;
 }
 
-// This API is used to uninitialize the SonicDBConfig class.
+// This API is used to reset the SonicDBConfig class.
 // And then user can call initialize with different config file.
-void SonicDBConfig::uninitialize()
+void SonicDBConfig::reset()
 {
     std::lock_guard<std::recursive_mutex> guard(m_db_info_mutex);
     m_init = false;

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -59,6 +59,7 @@ public:
             SonicDBConfig.initializeGlobalConfig(global_db_file_path)
     %}
 #endif
+    static void uninitialize();
 
     static void validateNamespace(const std::string &netns);
     static std::string getDbInst(const std::string &dbName, const std::string &netns = EMPTY_NAMESPACE);

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -59,7 +59,7 @@ public:
             SonicDBConfig.initializeGlobalConfig(global_db_file_path)
     %}
 #endif
-    static void uninitialize();
+    static void reset();
 
     static void validateNamespace(const std::string &netns);
     static std::string getDbInst(const std::string &dbName, const std::string &netns = EMPTY_NAMESPACE);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -70,6 +70,19 @@ public:
             EXPECT_TRUE(strstr(e.what(), "Namespace invalid is not a valid namespace name in config file"));
         }
 
+        // uninitialize SonicDBConfig, init should be false
+        SonicDBConfig::uninitialize();
+        cout<<"UNINIT: isInit = "<<SonicDBConfig::isInit()<<endl;
+        EXPECT_FALSE(SonicDBConfig::isInit());
+        EXPECT_FALSE(SonicDBConfig::isGlobalInit());
+
+        // reinitialize SonicDBConfig, init should be true
+        SonicDBConfig::initialize(existing_file);
+        cout<<"INIT: load local db config file, isInit = "<<SonicDBConfig::isInit()<<endl;
+        EXPECT_TRUE(SonicDBConfig::isInit());
+        SonicDBConfig::initializeGlobalConfig(global_existing_file);
+        cout<<"INIT: load global db config file, isInit = "<<SonicDBConfig::isGlobalInit()<<endl;
+        EXPECT_TRUE(SonicDBConfig::isGlobalInit());
     }
 };
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -70,9 +70,9 @@ public:
             EXPECT_TRUE(strstr(e.what(), "Namespace invalid is not a valid namespace name in config file"));
         }
 
-        // uninitialize SonicDBConfig, init should be false
-        SonicDBConfig::uninitialize();
-        cout<<"UNINIT: isInit = "<<SonicDBConfig::isInit()<<endl;
+        // reset SonicDBConfig, init should be false
+        SonicDBConfig::reset();
+        cout<<"RESET: isInit = "<<SonicDBConfig::isInit()<<endl;
         EXPECT_FALSE(SonicDBConfig::isInit());
         EXPECT_FALSE(SonicDBConfig::isGlobalInit());
 


### PR DESCRIPTION
#### Why I did it
sonic-gnmi will use swsscommon API to read database configuration, and sonic-gnmi unit test needs to reload database configuration in the same process.

#### How I did it
Add SonicDBConfig::reset method, and sonic-gnmi unit test will use this method to clear previous database configuration.

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202305
-->

- [ ] 202012
- [ ] 202205
- [ ] 202305

#### Description for the changelog
Add SonicDBConfig::reset method

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)