### PR TITLE
Use selectable event to terminate logger thread

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -49,6 +49,8 @@ void Logger::terminateSettingThread()
         m_settingThread->join();
 
         m_settingThread = nullptr;
+
+        m_stopEvent = nullptr;
     }
 }
 
@@ -56,7 +58,7 @@ void Logger::restartSettingThread()
 {
     terminateSettingThread();
 
-    m_stopEvent.reset(new SelectableEvent(0));
+    m_stopEvent = std::make_unique<SelectableEvent>(0);
 
     m_settingThread.reset(new std::thread(&Logger::settingThread, this));
 }

--- a/common/logger.h
+++ b/common/logger.h
@@ -10,6 +10,7 @@
 #include <functional>
 
 #include "concurrentmap.h"
+#include "selectableevent.h"
 
 namespace swss {
 
@@ -161,7 +162,7 @@ private:
     std::atomic<Output> m_output = { SWSS_SYSLOG };
     std::unique_ptr<std::thread> m_settingThread;
     std::mutex m_mutex;
-    volatile bool m_runSettingThread = true;
+    std::unique_ptr<SelectableEvent> m_stopEvent;
 };
 
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`settingThread` of `Logger` select DB change with 1000ms timeout. It causes up to 1 second wait while destroy the logger instance. The 1 second wait is not necessary and can be replaced by `SelectableEvent`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Add a new member m_stopEvent with type SelectableEvent
2. `settingThread` also selects m_stopEvent
3. `settingThread` exits if m_stopEvent comes 

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
