### PR TITLE
Add TupleHelper and SelectHelper to improve SWIG Go wrapper.

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -59,6 +59,7 @@ common_libswsscommon_la_SOURCES = \
     common/saiaclschema.cpp          \
     common/subscriberstatetable.cpp  \
     common/timestamp.cpp             \
+    common/tuplehelper.cpp           \
     common/warm_restart.cpp          \
     common/luatable.cpp              \
     common/countertable.cpp          \

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -38,26 +38,10 @@ protected:
 };
 
 #if defined(SWIG) && defined(SWIGGO)
-%go_import("fmt")
 %insert(go_wrapper) %{
 
 type ConfigDBConnector struct {
     ConfigDBConnector_Native
-}
-
-func (configDbConnector ConfigDBConnector) Hget(table string, key string, field string) (string, error) {
-    var fieldValuePairs = configDbConnector.Get_entry(table, key)
-    if fieldValuePairs.Has_key(field) {
-        return fieldValuePairs.Get(field), nil
-    }
-
-    return "", fmt.Errorf("Can't read %s:%s from %s table", key, field, table)
-}
-
-func (configDbConnector ConfigDBConnector) Hset(table string, key string, field string, value string) {
-    var fieldValuePairs = configDbConnector.Get_entry(table, key)
-    fieldValuePairs.Set(field, value)
-    configDbConnector.Set_entry(table, key, fieldValuePairs)
 }
 
 func NewConfigDBConnector(a ...interface{}) *ConfigDBConnector {

--- a/common/configdb.h
+++ b/common/configdb.h
@@ -37,6 +37,38 @@ protected:
     std::string m_db_name;
 };
 
+#if defined(SWIG) && defined(SWIGGO)
+%go_import("fmt")
+%insert(go_wrapper) %{
+
+type ConfigDBConnector struct {
+    ConfigDBConnector_Native
+}
+
+func (configDbConnector ConfigDBConnector) Hget(table string, key string, field string) (string, error) {
+    var fieldValuePairs = configDbConnector.Get_entry(table, key)
+    if fieldValuePairs.Has_key(field) {
+        return fieldValuePairs.Get(field), nil
+    }
+
+    return "", fmt.Errorf("Can't read %s:%s from %s table", key, field, table)
+}
+
+func (configDbConnector ConfigDBConnector) Hset(table string, key string, field string, value string) {
+    var fieldValuePairs = configDbConnector.Get_entry(table, key)
+    fieldValuePairs.Set(field, value)
+    configDbConnector.Set_entry(table, key, fieldValuePairs)
+}
+
+func NewConfigDBConnector(a ...interface{}) *ConfigDBConnector {
+    return &ConfigDBConnector{
+        NewConfigDBConnector_Native(a...),
+    }
+}
+%}
+#endif
+
+
 #if defined(SWIG) && defined(SWIGPYTHON)
 %pythoncode %{
     ## Note: diamond inheritance, reusing functions in both classes

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -214,4 +214,9 @@ std::string Select::resultToString(int result)
     }
 }
 
+void SelectHelper::DoSelect(Select& select, int timeout, bool interrupt_on_signal)
+{
+    m_result = select.select(&m_selectable, timeout, interrupt_on_signal);
+}
+
 };

--- a/common/select.h
+++ b/common/select.h
@@ -73,6 +73,27 @@ private:
     std::set<Selectable *, Select::cmp> m_ready;
 };
 
+class SelectHelper
+{
+public:
+    void DoSelect(Select& select, int timeout = -1, bool interrupt_on_signal = false);
+
+    Selectable &GetSelectable()
+    {
+        return *(m_selectable);
+    }
+
+    int GetResult()
+    {
+        return m_result;
+    }
+
+private:
+    Selectable *m_selectable;
+
+    int m_result;
+};
+
 }
 
 #endif

--- a/common/table.h
+++ b/common/table.h
@@ -10,6 +10,7 @@
 #include <deque>
 #include "hiredis/hiredis.h"
 #include "dbconnector.h"
+#include "rediscommand.h"
 #include "redisreply.h"
 #include "redisselect.h"
 #include "redispipeline.h"
@@ -20,14 +21,6 @@ namespace swss {
 
 // Mapping of DB ID to table name separator string
 typedef std::map<int, std::string> TableNameSeparatorMap;
-
-typedef std::pair<std::string, std::string> FieldValueTuple;
-#define fvField std::get<0>
-#define fvValue std::get<1>
-typedef std::tuple<std::string, std::string, std::vector<FieldValueTuple> > KeyOpFieldsValuesTuple;
-#define kfvKey    std::get<0>
-#define kfvOp     std::get<1>
-#define kfvFieldsValues std::get<2>
 
 typedef std::map<std::string,std::string> TableMap;
 typedef std::map<std::string,TableMap> TableDump;

--- a/common/tuplehelper.cpp
+++ b/common/tuplehelper.cpp
@@ -4,27 +4,27 @@ using namespace std;
 
 namespace swss {
 
-std::string TupleHelper::getField(const FieldValueTuple& tuple)
+const std::string& TupleHelper::getField(const FieldValueTuple& tuple)
 {
     return fvField(tuple);
 }
 
-std::string TupleHelper::getValue(const FieldValueTuple& tuple)
+const std::string& TupleHelper::getValue(const FieldValueTuple& tuple)
 {
     return fvValue(tuple);
 }
 
-std::string TupleHelper::getKey(const KeyOpFieldsValuesTuple& tuple)
+const std::string& TupleHelper::getKey(const KeyOpFieldsValuesTuple& tuple)
 {
     return kfvKey(tuple);
 }
 
-std::string TupleHelper::getOp(const KeyOpFieldsValuesTuple& tuple)
+const std::string& TupleHelper::getOp(const KeyOpFieldsValuesTuple& tuple)
 {
     return kfvOp(tuple);
 }
 
-std::vector<FieldValueTuple> TupleHelper::getFieldsValues(const KeyOpFieldsValuesTuple& tuple)
+const std::vector<FieldValueTuple>& TupleHelper::getFieldsValues(const KeyOpFieldsValuesTuple& tuple)
 {
     return kfvFieldsValues(tuple);
 }

--- a/common/tuplehelper.cpp
+++ b/common/tuplehelper.cpp
@@ -1,0 +1,32 @@
+#include "tuplehelper.h"
+
+using namespace std;
+
+namespace swss {
+
+std::string TupleHelper::getField(const FieldValueTuple& tuple)
+{
+    return fvField(tuple);
+}
+
+std::string TupleHelper::getValue(const FieldValueTuple& tuple)
+{
+    return fvValue(tuple);
+}
+
+std::string TupleHelper::getKey(const KeyOpFieldsValuesTuple& tuple)
+{
+    return kfvKey(tuple);
+}
+
+std::string TupleHelper::getOp(const KeyOpFieldsValuesTuple& tuple)
+{
+    return kfvOp(tuple);
+}
+
+std::vector<FieldValueTuple> TupleHelper::getFieldsValues(const KeyOpFieldsValuesTuple& tuple)
+{
+    return kfvFieldsValues(tuple);
+}
+
+}

--- a/common/tuplehelper.h
+++ b/common/tuplehelper.h
@@ -1,4 +1,4 @@
- #ifndef __TUPLE_HELPER__
+#ifndef __TUPLE_HELPER__
 #define __TUPLE_HELPER__
 
 #include <string>
@@ -13,15 +13,15 @@ namespace swss {
  */
 class TupleHelper {
 public:
-    static std::string getField(const FieldValueTuple& tuple);
+    static const std::string& getField(const FieldValueTuple& tuple);
     
-    static std::string getValue(const FieldValueTuple& tuple);
+    static const std::string& getValue(const FieldValueTuple& tuple);
 
-    static std::string getKey(const KeyOpFieldsValuesTuple& tuple);
+    static const std::string& getKey(const KeyOpFieldsValuesTuple& tuple);
     
-    static std::string getOp(const KeyOpFieldsValuesTuple& tuple);
+    static const std::string& getOp(const KeyOpFieldsValuesTuple& tuple);
     
-    static std::vector<FieldValueTuple> getFieldsValues(const KeyOpFieldsValuesTuple& tuple);
+    static const std::vector<FieldValueTuple>& getFieldsValues(const KeyOpFieldsValuesTuple& tuple);
 };
 
 }

--- a/common/tuplehelper.h
+++ b/common/tuplehelper.h
@@ -1,0 +1,28 @@
+ #ifndef __TUPLE_HELPER__
+#define __TUPLE_HELPER__
+
+#include <string>
+#include <vector>
+
+#include "rediscommand.h"
+
+namespace swss {
+
+/*
+    SWIG not support std::tuple https://www.swig.org/Doc4.0/SWIGDocumentation.html#CPlusPlus11_tuple_types
+ */
+class TupleHelper {
+public:
+    static std::string getField(const FieldValueTuple& tuple);
+    
+    static std::string getValue(const FieldValueTuple& tuple);
+
+    static std::string getKey(const KeyOpFieldsValuesTuple& tuple);
+    
+    static std::string getOp(const KeyOpFieldsValuesTuple& tuple);
+    
+    static std::vector<FieldValueTuple> getFieldsValues(const KeyOpFieldsValuesTuple& tuple);
+};
+
+}
+#endif

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -25,6 +25,7 @@
 #include "select.h"
 #include "selectable.h"
 #include "rediscommand.h"
+#include "tuplehelper.h"
 #include "table.h"
 #include "countertable.h"
 #include "redispipeline.h"
@@ -260,9 +261,20 @@ T castSelectableObj(swss::Selectable *temp)
 %include "sonicv2connector.h"
 %include "pubsub.h"
 %include "profileprovider.h"
+
+#ifdef SWIGGO
+// Generate inheritance information for Selectable and SubscriberStateTable
+%feature("director") swss::Selectable;
+%feature("director") swss::RedisSelect;
+%feature("director") swss::TableConsumable;
+%feature("director") swss::ConsumerTableBase;
+%feature("director") swss::SubscriberStateTable;
+#endif
+
 %include "selectable.h"
 %include "select.h"
 %include "rediscommand.h"
+%include "tuplehelper.h"
 %include "redispipeline.h"
 %include "redisreply.h"
 %include "redisselect.h"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,6 +42,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/binary_serializer_ut.cpp    \
                       tests/zmq_state_ut.cpp            \
                       tests/profileprovider_ut.cpp      \
+                      tests/go_helper_ut.cpp            \
                       tests/main.cpp
 
 tests_tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(LIBNL_CFLAGS)

--- a/tests/go_helper_ut.cpp
+++ b/tests/go_helper_ut.cpp
@@ -1,0 +1,100 @@
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <algorithm>
+#include "gtest/gtest.h"
+#include "common/dbconnector.h"
+#include "common/select.h"
+#include "common/selectableevent.h"
+#include "common/table.h"
+#include "common/subscriberstatetable.h"
+#include "common/tuplehelper.h"
+
+using namespace std;
+using namespace swss;
+
+#define NUMBER_OF_THREADS   (64) // Spawning more than 256 threads causes libc++ to except
+#define NUMBER_OF_OPS     (1000)
+#define MAX_FIELDS_DIV      (30) // Testing up to 30 fields objects
+#define PRINT_SKIP          (10) // Print + for Producer and - for Subscriber for every 100 ops
+
+static const string testTableName = "UT_REDIS_TABLE";
+static const string testTableName2 = "UT_REDIS_TABLE2";
+
+static inline string key(int index, int keyid)
+{
+    return string("key_") + to_string(index) + ":" + to_string(keyid);
+}
+
+static inline string field(int index, int keyid)
+{
+    return string("field ") + to_string(index) + ":" + to_string(keyid);
+}
+
+static inline string value(int index, int keyid)
+{
+    if (keyid == 0)
+    {
+        return string(); // empty
+    }
+
+    return string("value ") + to_string(index) + ":" + to_string(keyid);
+}
+
+
+static inline void clearDB()
+{
+    DBConnector db("TEST_DB", 0, true);
+    RedisReply r(&db, "FLUSHALL", REDIS_REPLY_STATUS);
+    r.checkStatusOK();
+}
+
+TEST(SelectHelper, select)
+{
+    clearDB();
+
+    /* Prepare producer */
+    DBConnector db("TEST_DB", 0, true);
+    Table p(&db, "MID_PLANE_BRIDGE");
+
+    /* Prepare subscriber */
+    SubscriberStateTable c(&db, "MID_PLANE_BRIDGE");
+    Select cs;
+    cs.addSelectable(&c);
+    SelectHelper helper;
+
+    /* Set operation */
+    p.hset("GLOBAL", "bridge", "bridge_midplane");
+
+    /* Pop operation */
+    helper.DoSelect(cs);
+    EXPECT_EQ(helper.GetResult(), Select::OBJECT);
+    KeyOpFieldsValuesTuple kco;
+    c.pop(kco);
+    EXPECT_EQ(kfvKey(kco), "GLOBAL");
+    EXPECT_EQ(kfvOp(kco), "SET");
+
+    auto fvs = kfvFieldsValues(kco);
+    EXPECT_EQ(fvs.size(), (unsigned int)(1));
+
+    EXPECT_EQ(fvField(fvs[0]), "bridge");
+    EXPECT_EQ(fvValue(fvs[0]), "bridge_midplane");
+}
+
+TEST(TupleHelper, select)
+{
+    KeyOpFieldsValuesTuple tuple{
+        "Key",
+        "SET",
+        std::vector<FieldValueTuple>{
+            {"Field", "Value"}
+        }};
+    
+    EXPECT_EQ(TupleHelper::getKey(tuple), "Key");
+    EXPECT_EQ(TupleHelper::getOp(tuple), "SET");
+
+    auto values = TupleHelper::getFieldsValues(tuple);
+    EXPECT_EQ(values.size(), 1);
+    EXPECT_EQ(TupleHelper::getField(values[0]), "Field");
+    EXPECT_EQ(TupleHelper::getValue(values[0]), "Value");
+}


### PR DESCRIPTION
#### Why I did it
SWIG not support std::tuple, also not support C++ inheritance well, this make go wrapper method of select and pops method does not work.

#### How I did it
Add TupleHelper and SelectHelper to improve SWIG Go wrapper. 

##### Work item tracking
- Microsoft ADO: 26731929

#### How to verify it
Pass all test cases.
Add new test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add TupleHelper and SelectHelper to improve SWIG Go wrapper. 

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

