### PR TITLE
Add connect/close/endpoint method to ZmqClient/ZmqServer.

### DIFF
--- a/common/zmqclient.cpp
+++ b/common/zmqclient.cpp
@@ -22,21 +22,7 @@ ZmqClient::ZmqClient(const std::string& endpoint)
 
 ZmqClient::~ZmqClient()
 {
-    std::lock_guard<std::mutex> lock(m_socketMutex);
-    if (m_socket)
-    {
-        int rc = zmq_close(m_socket);
-        if (rc != 0)
-        {
-            SWSS_LOG_ERROR("failed to close zmq socket, zmqerrno: %d",
-                    zmq_errno());
-        }
-    }
-
-    if (m_context)
-    {
-        zmq_ctx_destroy(m_context);
-    }
+    close();
 }
     
 void ZmqClient::initialize(const std::string& endpoint)
@@ -47,6 +33,11 @@ void ZmqClient::initialize(const std::string& endpoint)
     m_socket = nullptr;
 
     connect();
+}
+
+std::string ZmqClient::endpoint()
+{
+    return m_endpoint;
 }
     
 bool ZmqClient::isConnected()
@@ -100,6 +91,30 @@ void ZmqClient::connect()
     }
 
     m_connected = true;
+}
+
+void ZmqClient::close()
+{
+    std::lock_guard<std::mutex> lock(m_socketMutex);
+    if (m_socket)
+    {
+        int rc = zmq_close(m_socket);
+        if (rc != 0)
+        {
+            SWSS_LOG_ERROR("failed to close zmq socket, zmqerrno: %d",
+                    zmq_errno());
+        }
+
+        m_socket = nullptr;
+    }
+
+    if (m_context)
+    {
+        zmq_ctx_destroy(m_context);
+        m_context = nullptr;
+    }
+
+    m_connected = false;
 }
 
 void ZmqClient::sendMsg(

--- a/common/zmqclient.h
+++ b/common/zmqclient.h
@@ -17,7 +17,11 @@ public:
 
     bool isConnected();
 
+    std::string endpoint();
+
     void connect();
+
+    void close();
 
     void sendMsg(const std::string& dbName,
                  const std::string& tableName,

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -33,6 +33,12 @@ public:
     ZmqServer(const std::string& endpoint);
     ~ZmqServer();
 
+    std::string endpoint();
+
+    void connect();
+
+    void close();
+
     void registerMessageHandler(
                                 const std::string dbName,
                                 const std::string tableName,

--- a/tests/zmq_state_ut.cpp
+++ b/tests/zmq_state_ut.cpp
@@ -192,6 +192,7 @@ static void producerBatchWorker(string tableName, string endpoint, bool dbPersis
         }
     }
 
+    client.close();
     cout << "Producer thread ended: " << tableName << endl;
 }
 
@@ -268,6 +269,7 @@ static void consumerWorker(string tableName, string endpoint, bool dbPersistence
         }
     }
 
+    server.close();
     cout << "Consumer thread ended: " << tableName << endl;
 }
 


### PR DESCRIPTION
#### Why I did it
GO will manage resource by GC, ZmqClient/ZmqServer contains system resource need release explicitly.

#### How I did it
Add connect/close/endpoint method to ZmqClient/ZmqServer.

##### Work item tracking
- Microsoft ADO: 27350797

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add connect/close/endpoint method to ZmqClient/ZmqServer.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

