### PR TITLE
Remove the error log form SonicDBConfig::initializeGlobalConfig

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -84,7 +84,6 @@ void SonicDBConfig::initializeGlobalConfig(const string &file)
 
     if (m_global_init)
     {
-        SWSS_LOG_ERROR("SonicDBConfig Global config is already initialized");
         return;
     }
 


### PR DESCRIPTION
**Issue**: If run "show interfaces status" we often see the error in syslog "SonicDBConfig Global config is already initialized". 

**Analysis**: During investigation it is found the swsscommon.load_sonic_global_db_config() has been triggered multiple times. Espically in a multi Asic scenario.

CLI triggers "intfutil -c status" with a separate process. Within the process it will trigger IntfStatus __init__ --> MultiAsic() __init__-->load_db_config(). This time initializeGlobalConfig() will run to the end as m_global_init flag is false.

CLI will also run get_port_config() --> db_connect_configdb() --> load_db_config() (for different namepaces. In our case is asic0 and asic1).  This time m_global_init flag is true which causes error log and return.  

**Conclusion**: After researching we found load_db_config() could be called by different Classes. The code has already added protection to avoid to initialize global config multiple time. The error log is not necessary to be there. 

**Solution**: Removed the error log from initializeGlobalConfig() when found global config is already initialized. 