### PR TITLE
Add Bookworm build to PR checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,7 +128,7 @@ stages:
       arch: amd64
       sonic_slave: sonic-slave-bookworm:$(BUILD_BRANCH)
       artifact_name: sonic-swss-common-bookworm
-      debian_version: bookworm
+      debian_version: ${{ parameters.debian_version }}
 
   - template: .azure-pipelines/build-template.yml
     parameters:
@@ -137,7 +137,7 @@ stages:
       pool: sonicbld-armhf
       sonic_slave: sonic-slave-bookworm-armhf:$(BUILD_BRANCH)
       artifact_name: sonic-swss-common-bookworm.armhf
-      debian_version: bookworm
+      debian_version: ${{ parameters.debian_version }}
 
   - template: .azure-pipelines/build-template.yml
     parameters:
@@ -146,7 +146,7 @@ stages:
       pool: sonicbld-arm64
       sonic_slave: sonic-slave-bookworm-arm64:$(BUILD_BRANCH)
       artifact_name: sonic-swss-common-bookworm.arm64
-      debian_version: bookworm
+      debian_version: ${{ parameters.debian_version }}
 
 - stage: BuildSairedis
   dependsOn: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,6 +119,35 @@ stages:
       artifact_name: sonic-swss-common.arm64
       debian_version: ${{ parameters.debian_version }}
 
+- stage: BuildBookworm
+  dependsOn: BuildArm
+  condition: succeeded('BuildArm')
+  jobs:
+  - template: .azure-pipelines/build-template.yml
+    parameters:
+      arch: amd64
+      sonic_slave: sonic-slave-bookworm:$(BUILD_BRANCH)
+      artifact_name: sonic-swss-common-bookworm
+      debian_version: bookworm
+
+  - template: .azure-pipelines/build-template.yml
+    parameters:
+      arch: armhf
+      timeout: 180
+      pool: sonicbld-armhf
+      sonic_slave: sonic-slave-bookworm-armhf:$(BUILD_BRANCH)
+      artifact_name: sonic-swss-common-bookworm.armhf
+      debian_version: bookworm
+
+  - template: .azure-pipelines/build-template.yml
+    parameters:
+      arch: arm64
+      timeout: 180
+      pool: sonicbld-arm64
+      sonic_slave: sonic-slave-bookworm-arm64:$(BUILD_BRANCH)
+      artifact_name: sonic-swss-common-bookworm.arm64
+      debian_version: bookworm
+
 - stage: BuildSairedis
   dependsOn: Build
   condition: succeeded('Build')


### PR DESCRIPTION
Add a step to verify the build for Bookworm for amd64, armhf, and arm64.