### PR TITLE
Fix DBConnector and AsyncDBUpdater not use DBKey issue

### DIFF
--- a/common/asyncdbupdater.cpp
+++ b/common/asyncdbupdater.cpp
@@ -56,7 +56,7 @@ void AsyncDBUpdater::dbUpdateThread()
     pthread_setschedprio(pthread_self(), min_priority + 1);
 
     // Follow same logic in ConsumerStateTable: every received data will write to 'table'.
-    DBConnector db(m_db->getDbName(), 0, true);
+    DBConnector db(m_db->getDbName(), 0, true, m_db->getDBKey());
     Table table(&db, m_tableName);
     std::mutex cvMutex;
     std::unique_lock<std::mutex> cvLock(cvMutex);

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -632,6 +632,8 @@ void DBConnector::select(DBConnector *db)
 DBConnector::DBConnector(const DBConnector &other)
     : RedisContext(other)
     , m_dbId(other.m_dbId)
+    , m_dbName(other.m_dbName)
+    , m_key(other.m_key)
 {
     select(this);
 }


### PR DESCRIPTION
#### Why I did it
Fix DBConnector and AsyncDBUpdater not use DBKey issue.

#### How I did it
Improve code to use DBKey when clone DBConnector.

##### Work item tracking

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix DBConnector and AsyncDBUpdater not use DBKey issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

