### PR TITLE
sonic-db-cli: Don't use unix socket for redis_chassis.server

### DIFF
--- a/sonic-db-cli/sonic-db-cli.cpp
+++ b/sonic-db-cli/sonic-db-cli.cpp
@@ -139,14 +139,14 @@ int executeCommands(
     try
     {
         int db_id =  SonicDBConfig::getDbId(db_name, netns);
-        if (useUnixSocket)
+        auto host = SonicDBConfig::getDbHostname(db_name, netns);
+        if (useUnixSocket && host != "redis_chassis.server")
         {
             auto db_socket = SonicDBConfig::getDbSock(db_name, netns);
             client = make_shared<DBConnector>(db_id, db_socket, 0);
         }
         else
         {
-            auto host = SonicDBConfig::getDbHostname(db_name, netns);
             auto port = SonicDBConfig::getDbPort(db_name, netns);
             client = make_shared<DBConnector>(db_id, host, port, 0);
         }


### PR DESCRIPTION
Described in https://github.com/sonic-net/sonic-buildimage/issues/18733 we see that swss.sh will try to access `CHASSIS_APP_DB` via `sonic-db-cli`.
If we're on a multi-asic system it will include the `-n <asic>` argument.
Having the `-n <asic>` argument causes `sonic-db-cli` to use unix sockets due to https://github.com/sonic-net/sonic-swss-common/pull/797
If we use a unix socket to try to reach the supervisor from the LC the command will fail with:
```
admin@cmp217-5:/var/log$ sudo sonic-db-cli -n asic0 CHASSIS_APP_DB keys "*"
Invalid database name input : 'CHASSIS_APP_DB'
Unable to connect to redis (unix-socket): Cannot assign requested address
```

https://github.com/sonic-net/sonic-swss-common/pull/866 fixed a similar issue with database.sh by forcing a tcp connection when accessing `CHASSIS_APP_DB` (`redis_chassis.server`) specifically for the `PING` `SAVE` and `FLUSHALL` operations.
This change provides that same tcp connection override for the other operations.