### PR TITLE
[swig]: Fix swig template memory leak on issue 17025 

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -110,7 +110,7 @@ jobs:
       displayName: "Install gcovr 5.2 (for --exclude-throw-branches support)"
     - script: |
         set -ex
-        sudo pip install Pympler==0.8
+        sudo pip install Pympler==0.8 pytest
         sudo apt-get install -y redis-server
         sudo sed -i 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf
         sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -156,7 +156,7 @@
     SWIG_Python_AppendOutput($result, temp);
 }
 
-%typemap(in, fragment="SWIG_AsPtr_std_string")
+%typemap(in, fragment="SWIG_AsVal_std_string")
     const std::vector<std::pair< std::string,std::string >,std::allocator< std::pair< std::string,std::string > > > &
         (std::vector< std::pair< std::string,std::string >,std::allocator< std::pair< std::string,std::string > > > temp,
         int res) {
@@ -165,25 +165,30 @@
         temp.push_back(std::pair< std::string,std::string >());
         PyObject *item = PySequence_GetItem($input, i);
         if (!PyTuple_Check(item) || PyTuple_Size(item) != 2) {
+            Py_DECREF(item);
             SWIG_fail;
         }
         PyObject *key = PyTuple_GetItem(item, 0);
         PyObject *value = PyTuple_GetItem(item, 1);
-        std::string *ptr = (std::string *)0;
+        std::string str;
+
         if (PyBytes_Check(key)) {
             temp.back().first.assign(PyBytes_AsString(key), PyBytes_Size(key));
-        } else if (SWIG_AsPtr_std_string(key, &ptr)) {
-            temp.back().first = *ptr;
+        } else if (SWIG_AsVal_std_string(key, &str) != SWIG_ERROR) {
+            temp.back().first = str;
         } else {
+            Py_DECREF(item);
             SWIG_fail;
         }
         if (PyBytes_Check(value)) {
             temp.back().second.assign(PyBytes_AsString(value), PyBytes_Size(value));
-        } else if (SWIG_AsPtr_std_string(value, &ptr)) {
-            temp.back().second = *ptr;
+        } else if (SWIG_AsVal_std_string(value, &str) != SWIG_ERROR) {
+            temp.back().second = str;
         } else {
+            Py_DECREF(item);
             SWIG_fail;
         }
+        Py_DECREF(item);
     }
     $1 = &temp;
 }
@@ -194,6 +199,7 @@
         PyObject *item = PySequence_GetItem($input, i);
         if (!PyTuple_Check(item) || PyTuple_Size(item) != 2) {
             $1 = 0;
+            Py_DECREF(item);
             break;
         }
         PyObject *key = PyTuple_GetItem(item, 0);
@@ -205,8 +211,10 @@
             && !PyUnicode_Check(value)
             && !PyString_Check(value)) {
             $1 = 0;
+            Py_DECREF(item);
             break;
         }
+        Py_DECREF(item);
     }
 }
 

--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -871,11 +871,11 @@ def test_TableOpsMemoryLeak():
     OP_COUNT = 50000
     app_db = swsscommon.DBConnector("APPL_DB", 0, True)
     t = swsscommon.Table(app_db, "TABLE")
-    big_data = "x" * 10000
-    fvs = swsscommon.FieldValuePairs([(big_data, big_data)])
+    long_data = "x" * 100
+    fvs = swsscommon.FieldValuePairs([(long_data, long_data)])
     rss = psutil.Process(os.getpid()).memory_info().rss
     for _ in range(OP_COUNT):
-        t.set("big_data", fvs)
-        t.get("big_data")
+        t.set("long_data", fvs)
+        t.get("long_data")
     assert psutil.Process(os.getpid()).memory_info().rss - rss < OP_COUNT
 


### PR DESCRIPTION
Fix the issue https://github.com/sonic-net/sonic-buildimage/issues/17025 about Redis set activity

## Description
The issue reports a memory leak on the Redis set operations

## Reason
1. Didn't decrease the reference count after PySequence_GetItem
2. Use the inappropriate Swig API and didn't release the string of SWIG_AsPtr_std_string

## Fix:
1. Refer PR: https://github.com/sonic-net/sonic-swss-common/pull/859 from @praveenraja1
2. Replace the API SWIG_AsPtr_std_string to SWIG_AsVal_std_string

## Add unit test
To monitor there is no dramatic memory increment after a huge amount of Redis set operations.
