### PR TITLE
Use requests==2.31.0 instead of latest version to avoid test failure.

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -64,7 +64,7 @@ jobs:
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan
       sudo apt-get install -y python3-pip
-      sudo pip3 install pytest==4.6.2 attrs==19.1.0 exabgp==4.0.10 distro==1.5.0 docker>=4.4.1 redis==3.3.4 flaky==3.7.0
+      sudo pip3 install pytest==4.6.2 attrs==19.1.0 exabgp==4.0.10 distro==1.5.0 docker>=4.4.1 redis==3.3.4 flaky==3.7.0 requests==2.31.0
     displayName: "Install dependencies"
 
   - script: |


### PR DESCRIPTION
Python package requests' latest release 2.32.0 has issues with docker package.
Use old stable version 2.31.0 instead.