### PR TITLE
[swig]: Fix swig template memory leak on issue 17025

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -110,7 +110,7 @@ jobs:
       displayName: "Install gcovr 5.2 (for --exclude-throw-branches support)"
     - script: |
         set -ex
-        sudo pip install Pympler==0.8
+        sudo pip install Pympler==0.8 pytest psutil
         sudo apt-get install -y redis-server
         sudo sed -i 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf
         sudo sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -53,6 +53,8 @@
 #include "zmqclient.h"
 #include "zmqconsumerstatetable.h"
 #include "zmqproducerstatetable.h"
+#include <memory>
+#include <functional>
 %}
 
 %include <std_string.i>
@@ -152,31 +154,36 @@
     SWIG_Python_AppendOutput($result, temp);
 }
 
-%typemap(in, fragment="SWIG_AsPtr_std_string")
+%typemap(in, fragment="SWIG_AsVal_std_string")
     const std::vector<std::pair< std::string,std::string >,std::allocator< std::pair< std::string,std::string > > > &
         (std::vector< std::pair< std::string,std::string >,std::allocator< std::pair< std::string,std::string > > > temp,
         int res) {
     res = SWIG_OK;
     for (int i = 0; i < PySequence_Length($input); ++i) {
         temp.push_back(std::pair< std::string,std::string >());
-        PyObject *item = PySequence_GetItem($input, i);
-        if (!PyTuple_Check(item) || PyTuple_Size(item) != 2) {
+        std::unique_ptr<PyObject, std::function<void(PyObject *)> > item(
+            PySequence_GetItem($input, i), 
+            [](PyObject *ptr){
+                Py_DECREF(ptr);
+            });
+        if (!PyTuple_Check(item.get()) || PyTuple_Size(item.get()) != 2) {
             SWIG_fail;
         }
-        PyObject *key = PyTuple_GetItem(item, 0);
-        PyObject *value = PyTuple_GetItem(item, 1);
-        std::string *ptr = (std::string *)0;
+        PyObject *key = PyTuple_GetItem(item.get(), 0);
+        PyObject *value = PyTuple_GetItem(item.get(), 1);
+        std::string str;
+
         if (PyBytes_Check(key)) {
             temp.back().first.assign(PyBytes_AsString(key), PyBytes_Size(key));
-        } else if (SWIG_AsPtr_std_string(key, &ptr)) {
-            temp.back().first = *ptr;
+        } else if (SWIG_AsVal_std_string(key, &str) != SWIG_ERROR) {
+            temp.back().first = str;
         } else {
             SWIG_fail;
         }
         if (PyBytes_Check(value)) {
             temp.back().second.assign(PyBytes_AsString(value), PyBytes_Size(value));
-        } else if (SWIG_AsPtr_std_string(value, &ptr)) {
-            temp.back().second = *ptr;
+        } else if (SWIG_AsVal_std_string(value, &str) != SWIG_ERROR) {
+            temp.back().second = str;
         } else {
             SWIG_fail;
         }
@@ -187,13 +194,17 @@
 %typemap(typecheck) const std::vector< std::pair< std::string,std::string >,std::allocator< std::pair< std::string,std::string > > > &{
     $1 = 1;
     for (int i = 0; i < PySequence_Length($input); ++i) {
-        PyObject *item = PySequence_GetItem($input, i);
-        if (!PyTuple_Check(item) || PyTuple_Size(item) != 2) {
+        std::unique_ptr<PyObject, std::function<void(PyObject *)> > item(
+            PySequence_GetItem($input, i), 
+            [](PyObject *ptr){
+                Py_DECREF(ptr);
+            });
+        if (!PyTuple_Check(item.get()) || PyTuple_Size(item.get()) != 2) {
             $1 = 0;
             break;
         }
-        PyObject *key = PyTuple_GetItem(item, 0);
-        PyObject *value = PyTuple_GetItem(item, 1);
+        PyObject *key = PyTuple_GetItem(item.get(), 0);
+        PyObject *value = PyTuple_GetItem(item.get(), 1);
         if (!PyBytes_Check(key)
             && !PyUnicode_Check(key)
             && !PyString_Check(key)


### PR DESCRIPTION
Fix the issue https://github.com/sonic-net/sonic-buildimage/issues/17025 about Redis set activity

Wait PR: https://github.com/sonic-net/sonic-swss-common/pull/836 cherry-pick to 202311

## Description
The issue reports a memory leak on the Redis set operations

## Reason
1. Didn't decrease the reference count after PySequence_GetItem
2. Use the inappropriate Swig API and didn't release the string of SWIG_AsPtr_std_string

## Fix:
1. Refer PR: https://github.com/sonic-net/sonic-swss-common/pull/859 from @praveenraja1
2. Replace the API SWIG_AsPtr_std_string to SWIG_AsVal_std_string

## Add unit test
To monitor there is no dramatic memory increment after a huge amount of Redis set operations.
