### PR TITLE
Temporarily skip vstest

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -67,44 +67,6 @@ jobs:
       sudo pip3 install pytest==4.6.2 attrs==19.1.0 exabgp==4.0.10 distro==1.5.0 docker>=4.4.1 redis==3.3.4 flaky==3.7.0 requests==2.31.0
     displayName: "Install dependencies"
 
-  - script: |
-      set -ex
-      sudo docker load -i $(Build.ArtifactStagingDirectory)/download/docker-sonic-vs.gz
-      docker ps
-      ip netns list
-      pushd sonic-swss/tests
-
-      # run pytests in sets of 20   
-      all_tests=$(ls test_*.py)
-      all_tests="${all_tests} p4rt"
-      test_set=()
-      for test in ${all_tests}; do
-        test_set+=("${test}")
-        if [ ${#test_set[@]} -ge 20 ]; then
-          test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-          echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" --keeptb --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
-          container_count=$(docker ps -q -a | wc -l)
-          if [ ${container_count} -gt 0 ]; then
-            docker stop $(docker ps -q -a)
-            docker rm $(docker ps -q -a)
-          fi
-          test_set=()
-        fi
-      done
-      if [ ${#test_set[@]} -gt 0 ]; then
-        test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-        echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" --keeptb --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
-        container_count=$(docker ps -q -a | wc -l)
-        if [ ${container_count} -gt 0 ]; then
-          docker stop $(docker ps -q -a)
-          docker rm $(docker ps -q -a)
-        fi
-      fi
-
-      rm -rf $(Build.ArtifactStagingDirectory)/download
-    displayName: "Run vs tests"
-    ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-      continueOnError: true
 
   - task: PublishTestResults@2
     inputs:


### PR DESCRIPTION
sonic-swss-common pipeline requires sonic-swss's source code to build and test.
sonic-swss pipeline requires sonic-swss-common's artifact to build and test.
Temporarily skip the vstest, to get a workable swss-common build