### PR TITLE
[common] enable redispipeline to only publish after flush

### DIFF
--- a/common/producerstatetable.cpp
+++ b/common/producerstatetable.cpp
@@ -14,68 +14,24 @@ using namespace std;
 namespace swss {
 
 ProducerStateTable::ProducerStateTable(DBConnector *db, const string &tableName)
-    : ProducerStateTable(new RedisPipeline(db, 1), tableName, false)
+    : ProducerStateTable(new RedisPipeline(db, 1), tableName, false, false)
 {
     m_pipeowned = true;
 }
 
 ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &tableName, bool buffered)
+    : ProducerStateTable(pipeline, tableName, buffered, false) {}
+
+ProducerStateTable::ProducerStateTable(RedisPipeline *pipeline, const string &tableName, bool buffered, bool flushPub)
     : TableBase(tableName, SonicDBConfig::getSeparator(pipeline->getDBConnector()))
     , TableName_KeySet(tableName)
+    , m_flushPub(flushPub)
     , m_buffered(buffered)
     , m_pipeowned(false)
     , m_tempViewActive(false)
     , m_pipe(pipeline)
 {
-    // num in luaSet and luaDel means number of elements that were added to the key set,
-    // not including all the elements already present into the set.
-    string luaSet =
-        "local added = redis.call('SADD', KEYS[2], ARGV[2])\n"
-        "for i = 0, #KEYS - 3 do\n"
-        "    redis.call('HSET', KEYS[3 + i], ARGV[3 + i * 2], ARGV[4 + i * 2])\n"
-        "end\n"
-        " if added > 0 then \n"
-        "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
-        "end\n";
-    m_shaSet = m_pipe->loadRedisScript(luaSet);
-
-    string luaDel =
-        "local added = redis.call('SADD', KEYS[2], ARGV[2])\n"
-        "redis.call('SADD', KEYS[4], ARGV[2])\n"
-        "redis.call('DEL', KEYS[3])\n"
-        "if added > 0 then \n"
-        "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
-        "end\n";
-    m_shaDel = m_pipe->loadRedisScript(luaDel);
-
-    string luaBatchedSet =
-        "local added = 0\n"
-        "local idx = 2\n"
-        "for i = 0, #KEYS - 4 do\n"
-        "    added = added + redis.call('SADD', KEYS[2], KEYS[4 + i])\n"
-        "    for j = 0, tonumber(ARGV[idx]) - 1 do\n"
-        "        local attr = ARGV[idx + j * 2 + 1]\n"
-        "        local val = ARGV[idx + j * 2 + 2]\n"
-        "        redis.call('HSET', KEYS[3] .. KEYS[4 + i], attr, val)\n"
-        "    end\n"
-        "    idx = idx + tonumber(ARGV[idx]) * 2 + 1\n"
-        "end\n"
-        "if added > 0 then \n"
-        "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
-        "end\n";
-    m_shaBatchedSet = m_pipe->loadRedisScript(luaBatchedSet);
-
-    string luaBatchedDel =
-        "local added = 0\n"
-        "for i = 0, #KEYS - 5 do\n"
-        "    added = added + redis.call('SADD', KEYS[2], KEYS[5 + i])\n"
-        "    redis.call('SADD', KEYS[3], KEYS[5 + i])\n"
-        "    redis.call('DEL', KEYS[4] .. KEYS[5 + i])\n"
-        "end\n"
-        "if added > 0 then \n"
-        "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
-        "end\n";
-    m_shaBatchedDel = m_pipe->loadRedisScript(luaBatchedDel);
+    resetRedisScript();
 
     string luaClear =
         "redis.call('DEL', KEYS[1])\n"
@@ -98,9 +54,67 @@ ProducerStateTable::~ProducerStateTable()
     }
 }
 
+void ProducerStateTable::resetRedisScript()
+{
+    if (m_flushPub && m_buffered)
+        m_pipe->addChannel(getChannelName(m_pipe->getDbId()));
+
+    // num in luaSet and luaDel means number of elements that were added to the key set,
+    // not including all the elements already present into the set.
+    string luaSet =
+        "local added = redis.call('SADD', KEYS[2], ARGV[2])\n"
+        "for i = 0, #KEYS - 3 do\n"
+        "    redis.call('HSET', KEYS[3 + i], ARGV[3 + i * 2], ARGV[4 + i * 2])\n"
+        "end\n";
+
+    string luaDel =
+        "local added = redis.call('SADD', KEYS[2], ARGV[2])\n"
+        "redis.call('SADD', KEYS[4], ARGV[2])\n"
+        "redis.call('DEL', KEYS[3])\n";
+
+    string luaBatchedSet =
+        "local added = 0\n"
+        "local idx = 2\n"
+        "for i = 0, #KEYS - 4 do\n"
+        "    added = added + redis.call('SADD', KEYS[2], KEYS[4 + i])\n"
+        "    for j = 0, tonumber(ARGV[idx]) - 1 do\n"
+        "        local attr = ARGV[idx + j * 2 + 1]\n"
+        "        local val = ARGV[idx + j * 2 + 2]\n"
+        "        redis.call('HSET', KEYS[3] .. KEYS[4 + i], attr, val)\n"
+        "    end\n"
+        "    idx = idx + tonumber(ARGV[idx]) * 2 + 1\n"
+        "end\n";
+
+    string luaBatchedDel =
+        "local added = 0\n"
+        "for i = 0, #KEYS - 5 do\n"
+        "    added = added + redis.call('SADD', KEYS[2], KEYS[5 + i])\n"
+        "    redis.call('SADD', KEYS[3], KEYS[5 + i])\n"
+        "    redis.call('DEL', KEYS[4] .. KEYS[5 + i])\n"
+        "end\n";
+
+    if (!m_flushPub || !m_buffered)
+    {
+        string luaPub =
+            "if added > 0 then \n"
+            "    redis.call('PUBLISH', KEYS[1], ARGV[1])\n"
+            "end\n";
+        luaSet += luaPub;
+        luaDel += luaPub;
+        luaBatchedSet += luaPub;
+        luaBatchedDel += luaPub;
+    }
+
+    m_shaSet = m_pipe->loadRedisScript(luaSet);
+    m_shaDel = m_pipe->loadRedisScript(luaDel);
+    m_shaBatchedSet = m_pipe->loadRedisScript(luaBatchedSet);
+    m_shaBatchedDel = m_pipe->loadRedisScript(luaBatchedDel);
+}
+
 void ProducerStateTable::setBuffered(bool buffered)
 {
     m_buffered = buffered;
+    resetRedisScript();
 }
 
 void ProducerStateTable::set(const string &key, const vector<FieldValueTuple> &values,

--- a/common/producerstatetable.h
+++ b/common/producerstatetable.h
@@ -12,6 +12,7 @@ class ProducerStateTable : public TableBase, public TableName_KeySet
 public:
     ProducerStateTable(DBConnector *db, const std::string &tableName);
     ProducerStateTable(RedisPipeline *pipeline, const std::string &tableName, bool buffered = false);
+    ProducerStateTable(RedisPipeline *pipeline, const std::string &tableName, bool buffered, bool flushPub);
     virtual ~ProducerStateTable();
 
     void setBuffered(bool buffered);
@@ -51,6 +52,7 @@ public:
 
     void apply_temp_view();
 private:
+    bool m_flushPub;
     bool m_buffered;
     bool m_pipeowned;
     bool m_tempViewActive;
@@ -62,6 +64,8 @@ private:
     std::string m_shaClear;
     std::string m_shaApplyView;
     TableDump m_tempViewState;
+
+    void resetRedisScript();
 };
 
 }

--- a/common/producerstatetable.h
+++ b/common/producerstatetable.h
@@ -52,7 +52,7 @@ public:
 
     void apply_temp_view();
 private:
-    bool m_flushPub;
+    bool m_flushPub; // publish per piepeline flush intead of per redis script
     bool m_buffered;
     bool m_pipeowned;
     bool m_tempViewActive;
@@ -65,7 +65,7 @@ private:
     std::string m_shaApplyView;
     TableDump m_tempViewState;
 
-    void resetRedisScript();
+    void reloadRedisScript(); // redis script may change if m_buffered changes
 };
 
 }

--- a/tests/redis_piped_state_ut.cpp
+++ b/tests/redis_piped_state_ut.cpp
@@ -730,3 +730,57 @@ TEST(ConsumerStateTable, async_multitable)
 
     cout << endl << "Done." << endl;
 }
+
+TEST(ConsumerStateTable, flushPub)
+{
+    clearDB();
+
+    /* Prepare producer */
+    int index = 0;
+    string tableName = "UT_REDIS_THREAD_" + to_string(index);
+    DBConnector db(TEST_DB, 0, true);
+    RedisPipeline pipeline(&db);
+    ProducerStateTable p(&pipeline, tableName, true, true);
+    string key = "TheKey";
+    int maxNumOfFields = 2;
+
+    /* Set operation */
+    {
+        vector<FieldValueTuple> fields;
+        for (int j = 0; j < maxNumOfFields; j++)
+        {
+            FieldValueTuple t(field(j), value(j));
+            fields.push_back(t);
+        }
+        p.set(key, fields);
+    }
+
+    /* Del operation */
+    p.del(key);
+    p.flush();
+
+    /* Prepare consumer */
+    ConsumerStateTable c(&db, tableName);
+    Select cs;
+    Selectable *selectcs;
+    cs.addSelectable(&c);
+
+    /* First pop operation */
+    {
+        int ret = cs.select(&selectcs);
+        EXPECT_EQ(ret, Select::OBJECT);
+        KeyOpFieldsValuesTuple kco;
+        c.pop(kco);
+        EXPECT_EQ(kfvKey(kco), key);
+        EXPECT_EQ(kfvOp(kco), "DEL");
+
+        auto fvs = kfvFieldsValues(kco);
+        EXPECT_EQ(fvs.size(), 0U);
+    }
+
+    /* Second select operation */
+    {
+        int ret = cs.select(&selectcs, 1000);
+        EXPECT_EQ(ret, Select::TIMEOUT);
+    }
+}

--- a/tests/redis_piped_state_ut.cpp
+++ b/tests/redis_piped_state_ut.cpp
@@ -740,7 +740,9 @@ TEST(ConsumerStateTable, flushPub)
     string tableName = "UT_REDIS_THREAD_" + to_string(index);
     DBConnector db(TEST_DB, 0, true);
     RedisPipeline pipeline(&db);
-    ProducerStateTable p(&pipeline, tableName, true, true);
+    ProducerStateTable p(&pipeline, tableName, false, true);
+    p.setBuffered(true);
+
     string key = "TheKey";
     int maxNumOfFields = 2;
 


### PR DESCRIPTION
**What I did**
- optimize redispipeline flush performance by remove unnecessary publish commands
- add a new parameter`bool flushPub` in `producerstatetable` constructor function
     - to enable/disable batch publish feature
     - default value of `m_flushPub` is `false`, so no impact on existing codes
     - optimization is effective only explicitly set this option
- remove individual publish command from the `producerstatetable` APIs' lua scripts
- add a publish command when the pipeline flushes [if `m_flushPub` is `true`]

**Why I did it**

- save TCP traffic and increase fpmsyncd efficiency

It's a feature included in  [BGP Loading Optimization HLD #1521](https://github.com/sonic-net/SONiC/pull/1521)  ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/SONiC/1521)