### PR TITLE
[202405] Don't use unix socket on for redis_chassis.server (sonic-net#873)

### DIFF
--- a/sonic-db-cli/sonic-db-cli.cpp
+++ b/sonic-db-cli/sonic-db-cli.cpp
@@ -139,14 +139,14 @@ int executeCommands(
     try
     {
         int db_id =  SonicDBConfig::getDbId(db_name, netns);
-        if (useUnixSocket)
+        auto host = SonicDBConfig::getDbHostname(db_name, netns);
+        if (useUnixSocket && host != "redis_chassis.server")
         {
             auto db_socket = SonicDBConfig::getDbSock(db_name, netns);
             client = make_shared<DBConnector>(db_id, db_socket, 0);
         }
         else
         {
-            auto host = SonicDBConfig::getDbHostname(db_name, netns);
             auto port = SonicDBConfig::getDbPort(db_name, netns);
             client = make_shared<DBConnector>(db_id, host, port, 0);
         }


### PR DESCRIPTION
Redoing the cherry pick of https://github.com/sonic-net/sonic-swss-common/pull/873 to 202405 as the previous cherry-pick seems to be too old to build:
https://github.com/sonic-net/sonic-swss-common/pull/883