### PR TITLE
[azp]: Run VS tests in parallel

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -77,29 +77,11 @@ jobs:
       # run pytests in sets of 20   
       all_tests=$(ls test_*.py)
       all_tests="${all_tests} p4rt"
-      test_set=()
-      for test in ${all_tests}; do
-        test_set+=("${test}")
-        if [ ${#test_set[@]} -ge 20 ]; then
-          test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-          echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" --keeptb --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
-          container_count=$(docker ps -q -a | wc -l)
-          if [ ${container_count} -gt 0 ]; then
-            docker stop $(docker ps -q -a)
-            docker rm $(docker ps -q -a)
-          fi
-          test_set=()
-        fi
-      done
-      if [ ${#test_set[@]} -gt 0 ]; then
-        test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-        echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" --keeptb --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
-        container_count=$(docker ps -q -a | wc -l)
-        if [ ${container_count} -gt 0 ]; then
-          docker stop $(docker ps -q -a)
-          docker rm $(docker ps -q -a)
-        fi
-      fi
+
+      params="--keeptb"
+      RETRY=3
+      IMAGE_NAME=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
+      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo ./run-tests.sh "$IMAGE_NAME" "$params" "TEST_MODULE" "$RETRY"
 
       rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"


### PR DESCRIPTION
https://github.com/sonic-net/sonic-swss/pull/3019 introduced the ability to run VS tests in parallel to decrease execution time. Implement the same change for swss-common.