### PR TITLE
Account for control character as part of zmq_read_part

### DIFF
--- a/common/events_common.h
+++ b/common/events_common.h
@@ -312,8 +312,10 @@ struct serialization
         int rc = zmq_msg_recv(&msg, sock, flag);
         if (rc == 1) {
             char control_character = *(char*)zmq_msg_data(&msg);
-            if (control_character == 0x01) {
-                SWSS_LOG_INFO("Received subscription message when XSUB connect to XPUB");
+            if (control_character == 0x01 || control_character == 0x00) {
+                SWSS_LOG_INFO("Received subscription/unsubscription message when XSUB connect to XPUB: %c", control_character);
+            } else {
+                SWSS_LOG_DEBUG("Received non subscription based control character: %c", control_character);
             }
             rc = 0;
         } else if (rc != -1) {

--- a/common/events_common.h
+++ b/common/events_common.h
@@ -310,7 +310,13 @@ struct serialization
         more = 0;
         zmq_msg_init(&msg);
         int rc = zmq_msg_recv(&msg, sock, flag);
-        if (rc != -1) {
+        if (rc == 1) {
+            string control_character((const char*)zmq_msg_data(&msg), zmq_msg_size(&msg));
+            if (control_character.c_str() == "#001") {
+                SWSS_LOG_INFO("Received subscription message when XSUB connect to XPUB");
+            }
+            rc = 0;
+        } else if (rc != -1) {
             size_t more_size = sizeof (more);
 
             zmq_getsockopt (sock, ZMQ_RCVMORE, &more, &more_size);
@@ -318,8 +324,7 @@ struct serialization
             rc = zmsg_to_map(msg, data);
             RET_ON_ERR(rc == 0, "Failed to deserialize part rc=%d", rc);
             /* read more flag if message read fails to de-serialize */
-        }
-        else {
+        } else {
             /* override with zmq err */
             rc = zmq_errno();
             if (rc != 11) {
@@ -332,7 +337,7 @@ struct serialization
         return rc;
     }
 
-       
+
     template<typename DT>
     int
     zmq_send_part(void *sock, int flag, const DT &data)

--- a/common/events_common.h
+++ b/common/events_common.h
@@ -311,8 +311,8 @@ struct serialization
         zmq_msg_init(&msg);
         int rc = zmq_msg_recv(&msg, sock, flag);
         if (rc == 1) {
-            string control_character((const char*)zmq_msg_data(&msg), zmq_msg_size(&msg));
-            if (control_character.c_str() == "#001") {
+            char control_character = *(char*)zmq_msg_data(&msg);
+            if (control_character == 0x01) {
                 SWSS_LOG_INFO("Received subscription message when XSUB connect to XPUB");
             }
             rc = 0;

--- a/tests/events_common_ut.cpp
+++ b/tests/events_common_ut.cpp
@@ -124,10 +124,10 @@ TEST(events_common, send_recv_control_character)
 
     *(char*)zmq_msg_data(&ctrl_msg) = 0x01;
 
-    EXPECT_EQ(1, zmq_mesg_send(&ctrl_msg, sock_p0, 0));
+    EXPECT_EQ(1, zmq_msg_send(&ctrl_msg, sock_p0, 0));
 
     // First part will be read only and will return as 0, but will not be deserialized event
-    EXPECT_EQ(0, zmq_message_read(sock_p1, 0, source1, m1));
+    EXPECT_EQ(0, zmq_message_read(sock_p1, 0, source, m));
 
     EXPECT_EQ("", source);
     EXPECT_EQ(0, m.size());

--- a/tests/events_common_ut.cpp
+++ b/tests/events_common_ut.cpp
@@ -119,18 +119,28 @@ TEST(events_common, send_recv_control_character)
     string source;
     map<string, string> m;
 
-    zmq_msg_t ctrl_msg;
-    zmq_msg_init_size(&ctrl_msg, 1);
-
-    *(char*)zmq_msg_data(&ctrl_msg) = 0x01;
-
-    EXPECT_EQ(1, zmq_msg_send(&ctrl_msg, sock_p0, 0));
-
+    // Subscription based control character test
+    zmq_msg_t sub_msg;
+    zmq_msg_init_size(&sub_msg, 1);
+    *(char*)zmq_msg_data(&sub_msg) = 0x01;
+    EXPECT_EQ(1, zmq_msg_send(&sub_msg, sock_p0, 0));
+    zmq_msg_close(&sub_msg);
     // First part will be read only and will return as 0, but will not be deserialized event
     EXPECT_EQ(0, zmq_message_read(sock_p1, 0, source, m));
-
     EXPECT_EQ("", source);
     EXPECT_EQ(0, m.size());
+
+   // Non-subscription based control character test
+    zmq_msg_t ctrl_msg;
+    zmq_msg_init_size(&ctrl_msg, 1);
+    *(char*)zmq_msg_data(&ctrl_msg) = 0x07;
+    EXPECT_EQ(1, zmq_msg_send(&ctrl_msg, sock_p0, 0));
+    zmq_msg_close(&ctrl_msg);
+    // First part will be read only and will return as 0, but will not be deserialized event
+    EXPECT_EQ(0, zmq_message_read(sock_p1, 0, source, m));
+    EXPECT_EQ("", source);
+    EXPECT_EQ(0, m.size());
+
     zmq_close(sock_p0);
     zmq_close(sock_p1);
     zmq_ctx_term(zmq_ctx);


### PR DESCRIPTION
ADO: 28728116

Capturing control character in do_capture as part of eventd is difficult as control character can be delayed such that we it is not sometimes caught when initially starting capture service. (SUB -> PUB (part of zmq proxy)).

Instead of dropping the control character as part of eventd do_capture, I will drop it as part of zmq_message_read which eventd calls via events_service.

1) Check rc value of zmq_msg_recv
2) if rc == 1 (meaning 1 byte long)
3) verify it is control character, log that we received subscription messages
4) drop it such that empty event is sent (empty events are dropped by eventd)

LIBZMQ: Control character logic: https://github.com/zeromq/libzmq/blob/cbb9925a109152426e4a8a3f8f8eaeddc0516977/src/xsub.cpp#L102

Added UT to confirm, as well as should see success rate of sonic-mgmt testcases go up for telemetry/test_events