### PR TITLE
[swig]: Fix swig template memory leak on issue 17025  (#876)

### DIFF
--- a/tests/test_redis_ut.py
+++ b/tests/test_redis_ut.py
@@ -831,3 +831,30 @@ def test_TableOpsMemoryLeak():
         t.get("long_data")
     assert psutil.Process(os.getpid()).memory_info().rss - rss < OP_COUNT
 
+
+def test_TableSetBinary():
+    app_db = swsscommon.DBConnector("APPL_DB", 0, True)
+    t = swsscommon.Table(app_db, "TABLE")
+    buff = b""
+    for i in range(0, 256):
+        buff += bytes([i])
+    buff = buff.decode('latin-1')
+    fvs = swsscommon.FieldValuePairs([("binary", buff)])
+    t.set("binary", fvs)
+    (status, fvs) = t.get("binary")
+    assert status == True
+    assert fvs[0][1] == buff
+
+
+def test_TableOpsMemoryLeak():
+    OP_COUNT = 50000
+    app_db = swsscommon.DBConnector("APPL_DB", 0, True)
+    t = swsscommon.Table(app_db, "TABLE")
+    long_data = "x" * 100
+    fvs = swsscommon.FieldValuePairs([(long_data, long_data)])
+    rss = psutil.Process(os.getpid()).memory_info().rss
+    for _ in range(OP_COUNT):
+        t.set("long_data", fvs)
+        t.get("long_data")
+    assert psutil.Process(os.getpid()).memory_info().rss - rss < OP_COUNT
+


### PR DESCRIPTION
Fix the issue https://github.com/sonic-net/sonic-buildimage/issues/17025 about Redis set activity

## Description
The issue reports a memory leak on the Redis set operations

## Reason
1. Didn't decrease the reference count after PySequence_GetItem
2. Use the inappropriate Swig API and didn't release the string of SWIG_AsPtr_std_string

## Fix:
1. Refer PR: https://github.com/sonic-net/sonic-swss-common/pull/859 from @praveenraja1
2. Replace the API SWIG_AsPtr_std_string to SWIG_AsVal_std_string

## Add unit test
To monitor there is no dramatic memory increment after a huge amount of Redis set operations.
