### PR TITLE
Add support for CHASSIS_COUNTERS_DB and schema for aggregate VOQ stats

### DIFF
--- a/common/database_config.json
+++ b/common/database_config.json
@@ -91,6 +91,11 @@
             "id" : 14,
             "separator": ":",
             "instance" : "redis"
+        },
+        "CHASSIS_COUNTERS_DB" : {
+            "id" : 21,
+            "separator": ":",
+            "instance" : "redis_chassis"
         }
     },
     "VERSION" : "1.0"

--- a/common/schema.h
+++ b/common/schema.h
@@ -25,6 +25,7 @@ namespace swss {
 #define APPL_STATE_DB       14
 #define EVENT_DB            19
 #define BMP_STATE_DB        20
+#define CHASSIS_COUNTERS_DB 21
 
 /***** APPLICATION DATABASE *****/
 
@@ -232,6 +233,8 @@ namespace swss {
 #define USER_WATERMARKS_TABLE          "USER_WATERMARKS"
 
 #define RATES_TABLE                         "RATES"
+
+#define CHASSIS_COUNTERS_VOQ           "COUNTERS_VOQ"
 
 /***** EVENTS COUNTER KEYS *****/
 #define COUNTERS_EVENTS_PUBLISHED           "published"


### PR DESCRIPTION
Changes in this pull request

1. Added support for new CHASSIS_COUNTERS_DB in redis_chassis instance of SSI for chassis based systems.
2. New table COUNTERS_VOQ in the same database to store VOQ stats.

Should merge after [#20057](https://github.com/sonic-net/sonic-buildimage/pull/20057)
Tracked by [#1543](https://github.com/sonic-net/SONiC/issues/1543)
HLD: [#1587](https://github.com/sonic-net/SONiC/pull/1587)