### PR TITLE
Add missing flex counter operations to consumer_table_pops.lua used in async mode

### DIFF
--- a/common/consumer_table_pops.lua
+++ b/common/consumer_table_pops.lua
@@ -90,7 +90,12 @@ for i = n, 1, -3 do
        op == 'object_type_get_availability_query' or
        op == 'object_type_get_availability_response' or
        op == 'stats_capability_query' or
-       op == 'stats_capability_response' then
+       op == 'stats_capability_response' or
+       op == 'start_poll' or
+       op == 'stop_poll' or
+       op == 'set_counter_group' or
+       op == 'del_counter_group' or
+       op == 'counter_response'then
 
     -- do not modify db entries when spotted those commands, they are used to
     -- trigger actions or get data synchronously from database


### PR DESCRIPTION
when configure  "synchronous_mode": "disable" the syncd and swss containers crashes
because of missing flex-counter operations in consumer_table_pops.lua

Fixed Problems/New Changes:

https://github.com/sonic-net/sonic-swss-common/issues/917

Should be Tested: