### PR TITLE
Add VRF support to ZMQ server/client

### DIFF
--- a/common/zmqclient.h
+++ b/common/zmqclient.h
@@ -13,6 +13,7 @@ class ZmqClient
 {
 public:
     ZmqClient(const std::string& endpoint);
+    ZmqClient(const std::string& endpoint, const std::string& vrf);
     ~ZmqClient();
 
     bool isConnected();
@@ -24,10 +25,11 @@ public:
                  const std::vector<KeyOpFieldsValuesTuple>& kcos,
                  std::vector<char>& sendbuffer);
 private:
-    void initialize(const std::string& endpoint);
-
+    void initialize(const std::string& endpoint, const std::string& vrf);
 
     std::string m_endpoint;
+
+    std::string m_vrf;
 
     void* m_context;
 

--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -31,6 +31,7 @@ public:
     static constexpr int DEFAULT_POP_BATCH_SIZE = 128;
 
     ZmqServer(const std::string& endpoint);
+    ZmqServer(const std::string& endpoint, const std::string& vrf);
     ~ZmqServer();
 
     void registerMessageHandler(
@@ -52,6 +53,8 @@ private:
     std::shared_ptr<std::thread> m_mqPollThread;
 
     std::string m_endpoint;
+
+    std::string m_vrf;
 
     std::map<std::string, std::map<std::string, ZmqMessageHandler*>> m_HandlerMap;
 };


### PR DESCRIPTION
#### Why I did it
Orchagent failed bind to ZMQ when mgmt VRF enabled: https://github.com/sonic-net/sonic-buildimage/issues/19638

#### How I did it
Add VRF support to ZMQ server/client.

##### Work item tracking

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add VRF support to ZMQ server/client.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

