### PR TITLE
Add BinarySerializer function that uses a thread-local shared buffer, and fix errors

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -68,7 +68,8 @@ common_libswsscommon_la_SOURCES = \
     common/zmqclient.cpp             \
     common/zmqserver.cpp             \
     common/asyncdbupdater.cpp        \
-    common/redis_table_waiter.cpp
+    common/redis_table_waiter.cpp    \
+    common/binaryserializer.cpp
 
 common_libswsscommon_la_CXXFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CFLAGS) $(CODE_COVERAGE_CXXFLAGS)
 common_libswsscommon_la_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(LIBNL_CPPFLAGS) $(CODE_COVERAGE_CPPFLAGS)

--- a/common/binaryserializer.cpp
+++ b/common/binaryserializer.cpp
@@ -57,6 +57,7 @@ class SerializerHelper {
 };
 
 namespace swss {
+namespace BinarySerializer {
 
 BufferSlice serializeSharedBuffer(const std::string &dbName, const std::string &tableName,
                                   const std::vector<KeyOpFieldsValuesTuple> &kcos) {
@@ -168,4 +169,5 @@ void deserializeBuffer(const char *buffer, const size_t size, std::string &dbNam
     }
 }
 
+} // namespace BinarySerializer
 } // namespace swss

--- a/common/binaryserializer.cpp
+++ b/common/binaryserializer.cpp
@@ -1,0 +1,161 @@
+#include <cstring>
+
+#include "binaryserializer.h"
+
+using namespace std;
+
+template <class T> static inline T read_unaligned(const char *buffer) {
+    T t;
+    std::memcpy(&t, buffer, sizeof(T));
+    return t;
+}
+
+template <class T> static inline void write_unaligned(char *buffer, T t) {
+    std::memcpy(buffer, &t, sizeof(T));
+}
+
+class SerializerHelper {
+    char *m_buffer;
+    size_t m_buffer_size;
+    char *m_current_position;
+    size_t m_kvp_count;
+
+  public:
+    SerializerHelper(char *buffer, size_t size)
+        : m_buffer(buffer), m_buffer_size(size), m_current_position(buffer + sizeof(size_t)),
+          m_kvp_count(0) {}
+
+    void setKeyAndValue(const char *key, size_t klen, const char *value, size_t vlen) {
+        setData(key, klen);
+        setData(value, vlen);
+        m_kvp_count++;
+    }
+
+    size_t finalize() {
+        // Write key/value pair count to the beginning of the buffer
+        write_unaligned(m_buffer, m_kvp_count);
+
+        // return total serialized length
+        return static_cast<size_t>(m_current_position - m_buffer);
+    }
+
+    void setData(const char *data, size_t datalen) {
+        if ((static_cast<size_t>(m_current_position - m_buffer) + datalen + sizeof(size_t)) >
+            m_buffer_size) {
+            SWSS_LOG_THROW("There is not enough buffer to serialize: current key count: %zu, "
+                           "current data length: %zu, buffer size: %zu",
+                           m_kvp_count, datalen, m_buffer_size);
+        }
+        write_unaligned(m_current_position, datalen);
+        m_current_position += sizeof(size_t);
+
+        std::memcpy(m_current_position, data, datalen);
+        m_current_position += datalen;
+    }
+};
+
+namespace swss {
+
+size_t serializeBuffer(char *buffer, size_t size, const std::string &dbName,
+                       const std::string &tableName,
+                       const std::vector<swss::KeyOpFieldsValuesTuple> &kcos) {
+
+    auto tmpSerializer = SerializerHelper(buffer, size);
+
+    // Set the first pair as DB name and table name.
+    tmpSerializer.setKeyAndValue(dbName.c_str(), dbName.length(), tableName.c_str(),
+                                 tableName.length());
+    for (auto &kco : kcos) {
+        auto &key = kfvKey(kco);
+        auto &fvs = kfvFieldsValues(kco);
+        std::string fvs_len = std::to_string(fvs.size());
+        // For each request, the first pair is the key and the number of attributes,
+        // followed by the attribute pairs.
+        // The operation is not set, when there is no attribute, it is a DEL request.
+        tmpSerializer.setKeyAndValue(key.c_str(), key.length(), fvs_len.c_str(), fvs_len.length());
+        for (auto &fv : fvs) {
+            auto &field = fvField(fv);
+            auto &value = fvValue(fv);
+            tmpSerializer.setKeyAndValue(field.c_str(), field.length(), value.c_str(),
+                                         value.length());
+        }
+    }
+
+    return tmpSerializer.finalize();
+}
+
+void deserializeBuffer(const char *buffer, size_t size,
+                       std::vector<swss::FieldValueTuple> &values) {
+    size_t kvp_count = read_unaligned<size_t>(buffer);
+    auto tmp_buffer = buffer + sizeof(size_t);
+    while (kvp_count > 0) {
+        kvp_count--;
+
+        // read field name
+        size_t keylen = read_unaligned<size_t>(tmp_buffer);
+        tmp_buffer += sizeof(size_t);
+        if ((size_t)(tmp_buffer - buffer) + keylen > size) {
+            SWSS_LOG_THROW(
+                "serialized key data was truncated, key length: %zu, increase buffer size: %zu",
+                keylen, size);
+        }
+        auto pkey = string(tmp_buffer, keylen);
+        tmp_buffer += keylen;
+
+        // read value
+        size_t vallen = read_unaligned<size_t>(tmp_buffer);
+        tmp_buffer += sizeof(size_t);
+        if ((size_t)(tmp_buffer - buffer) + vallen > size) {
+            SWSS_LOG_THROW("serialized value data was truncated, value length: %zu increase "
+                           "buffer size: %zu",
+                           vallen, size);
+        }
+        auto pval = string(tmp_buffer, vallen);
+        tmp_buffer += vallen;
+
+        values.push_back(std::make_pair(pkey, pval));
+    }
+}
+
+void deserializeBuffer(const char *buffer, const size_t size, std::string &dbName,
+                       std::string &tableName,
+                       std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos) {
+    std::vector<FieldValueTuple> values;
+    deserializeBuffer(buffer, size, values);
+    int fvs_size = -1;
+    KeyOpFieldsValuesTuple kco;
+    auto &key = kfvKey(kco);
+    auto &op = kfvOp(kco);
+    auto &fvs = kfvFieldsValues(kco);
+    for (auto &fv : values) {
+        auto &field = fvField(fv);
+        auto &value = fvValue(fv);
+        // The first pair is the DB name and the table name.
+        if (fvs_size < 0) {
+            dbName = field;
+            tableName = value;
+            fvs_size = 0;
+            continue;
+        }
+        // This is the beginning of a request.
+        // The first pair is the key and the number of attributes.
+        // If the attribute count is zero, it is a DEL request.
+        if (fvs_size == 0) {
+            key = field;
+            fvs_size = std::stoi(value);
+            op = (fvs_size == 0) ? DEL_COMMAND : SET_COMMAND;
+            fvs.clear();
+        }
+        // This is an attribut pair.
+        else {
+            fvs.push_back(fv);
+            --fvs_size;
+        }
+        // We got the last attribute pair. This is the end of a request.
+        if (fvs_size == 0) {
+            kcos.push_back(std::make_shared<KeyOpFieldsValuesTuple>(kco));
+        }
+    }
+}
+
+} // namespace swss

--- a/common/binaryserializer.h
+++ b/common/binaryserializer.h
@@ -1,215 +1,22 @@
 #ifndef __BINARY_SERIALIZER__
 #define __BINARY_SERIALIZER__
 
-#include "common/armhelper.h"
-
 #include <string>
+#include <vector>
 
-using namespace std;
+#include "table.h"
 
 namespace swss {
 
-class BinarySerializer {
-public:
-    static size_t serializeBuffer(
-        const char* buffer,
-        const size_t size,
-        const std::string& dbName,
-        const std::string& tableName,
-        const std::vector<KeyOpFieldsValuesTuple>& kcos)
-    {
-        auto tmpSerializer = BinarySerializer(buffer, size);
+size_t serializeBuffer(char *buffer, size_t size, const std::string &dbName,
+                       const std::string &tableName,
+                       const std::vector<swss::KeyOpFieldsValuesTuple> &kcos);
 
-        // Set the first pair as DB name and table name.
-        tmpSerializer.setKeyAndValue(
-                                    dbName.c_str(), dbName.length(),
-                                    tableName.c_str(), tableName.length());
-        for (auto& kco : kcos)
-        {
-            auto& key = kfvKey(kco);
-            auto& fvs = kfvFieldsValues(kco);
-            std::string fvs_len = std::to_string(fvs.size());
-            // For each request, the first pair is the key and the number of attributes,
-            // followed by the attribute pairs.
-            // The operation is not set, when there is no attribute, it is a DEL request.
-            tmpSerializer.setKeyAndValue(
-                                        key.c_str(), key.length(),
-                                        fvs_len.c_str(), fvs_len.length());
-            for (auto& fv : fvs)
-            {
-                auto& field = fvField(fv);
-                auto& value = fvValue(fv);
-                tmpSerializer.setKeyAndValue(
-                                            field.c_str(), field.length(),
-                                            value.c_str(), value.length());
-            }
-        }
+void deserializeBuffer(const char *buffer, size_t size, std::vector<swss::FieldValueTuple> &values);
 
-        return tmpSerializer.finalize();
-    }
+void deserializeBuffer(const char *buffer, const size_t size, std::string &dbName,
+                       std::string &tableName,
+                       std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos);
 
-    static void deserializeBuffer(
-        const char* buffer,
-        const size_t size,
-        std::vector<swss::FieldValueTuple>& values)
-    {
-        WARNINGS_NO_CAST_ALIGN;
-        auto pkvp_count = (const size_t*)buffer;
-        WARNINGS_RESET;
-
-        size_t kvp_count = *pkvp_count;
-        auto tmp_buffer = buffer + sizeof(size_t);
-        while (kvp_count > 0)
-        {
-            kvp_count--;
-
-            // read key and value from buffer
-            WARNINGS_NO_CAST_ALIGN;
-            auto pkeylen = (const size_t*)tmp_buffer;
-            WARNINGS_RESET;
-
-            tmp_buffer += sizeof(size_t);
-            if ((size_t)(tmp_buffer - buffer + *pkeylen)  > size)
-            {
-                SWSS_LOG_THROW("serialized key data was truncated, key length: %zu, increase buffer size: %zu",
-                                                                                            *pkeylen,
-                                                                                            size);
-            }
-
-            auto pkey = string(tmp_buffer, *pkeylen);
-            tmp_buffer += *pkeylen;
-
-            WARNINGS_NO_CAST_ALIGN;
-            auto pvallen = (const size_t*)tmp_buffer;
-            WARNINGS_RESET;
-
-            tmp_buffer += sizeof(size_t);
-            if ((size_t)(tmp_buffer - buffer + *pvallen)  > size)
-            {
-                SWSS_LOG_THROW("serialized value data was truncated,, value length: %zu increase buffer size: %zu",
-                                                                                            *pvallen,
-                                                                                            size);
-            }
-            
-            auto pval = string(tmp_buffer, *pvallen);
-            tmp_buffer += *pvallen;
-
-            values.push_back(std::make_pair(pkey, pval));
-        }
-    }
-
-    static void deserializeBuffer(
-        const char* buffer,
-        const size_t size,
-        std::string& dbName,
-        std::string& tableName,
-        std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>>& kcos)
-    {
-        std::vector<FieldValueTuple> values;
-        deserializeBuffer(buffer, size, values);
-        int fvs_size = -1;
-        KeyOpFieldsValuesTuple kco;
-        auto& key = kfvKey(kco);
-        auto& op = kfvOp(kco);
-        auto& fvs = kfvFieldsValues(kco);
-        for (auto& fv : values)
-        {
-            auto& field = fvField(fv);
-            auto& value = fvValue(fv);
-            // The first pair is the DB name and the table name.
-            if (fvs_size < 0)
-            {
-                dbName = field;
-                tableName = value;
-                fvs_size = 0;
-                continue;
-            }
-            // This is the beginning of a request.
-            // The first pair is the key and the number of attributes.
-            // If the attribute count is zero, it is a DEL request.
-            if (fvs_size == 0)
-            {
-                key = field;
-                fvs_size = std::stoi(value);
-                op = (fvs_size == 0) ? DEL_COMMAND : SET_COMMAND;
-                fvs.clear();
-            }
-            // This is an attribut pair.
-            else
-            {
-                fvs.push_back(fv);
-                --fvs_size;
-            }
-            // We got the last attribut pair. This is the end of a request.
-            if (fvs_size == 0)
-            {
-                kcos.push_back(std::make_shared<KeyOpFieldsValuesTuple>(kco));
-            }
-        }
-    }
-
-private:
-    const char* m_buffer;
-    const size_t m_buffer_size;
-    char* m_current_position;
-    size_t m_kvp_count;
-
-    BinarySerializer(const char* buffer, const size_t size)
-        : m_buffer(buffer), m_buffer_size(size)
-    {
-        resetSerializer();
-    }
-
-    void resetSerializer()
-    {
-        m_current_position = const_cast<char*>(m_buffer) + sizeof(size_t);
-        m_kvp_count = 0;
-    }
-
-    void setKeyAndValue(const char* key, size_t klen,
-                        const char* value, size_t vlen)
-    {
-        setData(key, klen);
-        setData(value, vlen);
-
-        m_kvp_count++;
-    }
-
-    size_t finalize()
-    {
-        // set key value pair count to message
-        WARNINGS_NO_CAST_ALIGN;
-        size_t* pkvp_count = (size_t*)const_cast<char*>(m_buffer);
-        WARNINGS_RESET;
-
-        *pkvp_count = m_kvp_count;
-
-        // return size
-        return m_current_position - m_buffer;
-    }
-
-    void setData(const char* data, size_t datalen)
-    {
-        if ((size_t)(m_current_position - m_buffer + datalen + sizeof(size_t)) > m_buffer_size)
-        {
-            SWSS_LOG_THROW("There are not enough buffer for binary serializer to serialize,\
-                             key count: %zu, data length %zu, buffer size: %zu",
-                                                m_kvp_count,
-                                                datalen,
-                                                m_buffer_size);
-        }
-
-        WARNINGS_NO_CAST_ALIGN;
-        size_t* pdatalen = (size_t*)m_current_position;
-        WARNINGS_RESET;
-
-        *pdatalen = datalen;
-        m_current_position += sizeof(size_t);
-
-        memcpy(m_current_position, data, datalen);
-        m_current_position += datalen;
-    }
-};
-
-}
+} // namespace swss
 #endif

--- a/common/binaryserializer.h
+++ b/common/binaryserializer.h
@@ -8,6 +8,18 @@
 
 namespace swss {
 
+struct BufferSlice {
+    const char *data;
+    size_t len;
+};
+
+const size_t SERIALIZE_SHARED_BUFFER_SIZE = 1024 * 1024 * 16;
+
+// Serialize into and return a shared, thread-local buffer. Since the buffer is reused, the returned
+// BufferSlice is invalidated upon calling this function again.
+BufferSlice serializeSharedBuffer(const std::string &dbName, const std::string &tableName,
+                                  const std::vector<KeyOpFieldsValuesTuple> &kcos);
+
 size_t serializeBuffer(char *buffer, size_t size, const std::string &dbName,
                        const std::string &tableName,
                        const std::vector<swss::KeyOpFieldsValuesTuple> &kcos);

--- a/common/binaryserializer.h
+++ b/common/binaryserializer.h
@@ -7,6 +7,7 @@
 #include "table.h"
 
 namespace swss {
+namespace BinarySerializer {
 
 struct BufferSlice {
     const char *data;
@@ -30,5 +31,6 @@ void deserializeBuffer(const char *buffer, const size_t size, std::string &dbNam
                        std::string &tableName,
                        std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos);
 
+} // namespace BinarySerializer
 } // namespace swss
 #endif

--- a/common/zmqclient.cpp
+++ b/common/zmqclient.cpp
@@ -119,7 +119,7 @@ void ZmqClient::sendMsg(
         const std::vector<KeyOpFieldsValuesTuple>& kcos,
         std::vector<char>& sendbuffer)
 {
-    size_t serializedlen = serializeBuffer(sendbuffer.data(), sendbuffer.size(), dbName, tableName, kcos);
+    size_t serializedlen = BinarySerializer::serializeBuffer(sendbuffer.data(), sendbuffer.size(), dbName, tableName, kcos);
 
     if (serializedlen >= MQ_RESPONSE_MAX_COUNT)
     {

--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -73,7 +73,7 @@ void ZmqServer::handleReceivedData(const char* buffer, const size_t size)
     std::string dbName;
     std::string tableName;
     std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos;
-    BinarySerializer::deserializeBuffer(buffer, size, dbName, tableName, kcos);
+    deserializeBuffer(buffer, size, dbName, tableName, kcos);
 
     // find handler
     auto handler = findMessageHandler(dbName, tableName);

--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -73,7 +73,7 @@ void ZmqServer::handleReceivedData(const char* buffer, const size_t size)
     std::string dbName;
     std::string tableName;
     std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos;
-    deserializeBuffer(buffer, size, dbName, tableName, kcos);
+    BinarySerializer::deserializeBuffer(buffer, size, dbName, tableName, kcos);
 
     // find handler
     auto handler = findMessageHandler(dbName, tableName);

--- a/tests/binary_serializer_ut.cpp
+++ b/tests/binary_serializer_ut.cpp
@@ -24,12 +24,7 @@ TEST(BinarySerializer, serialize_deserialize)
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{test_entry_key, test_command, values},
         KeyOpFieldsValuesTuple{test_entry_key2, test_command2, std::vector<FieldValueTuple>{}}};
-    int serialized_len = (int)BinarySerializer::serializeBuffer(
-                                                                buffer,
-                                                                sizeof(buffer),
-                                                                test_db,
-                                                                test_table,
-                                                                kcos);
+    size_t serialized_len = serializeBuffer(buffer, sizeof(buffer), test_db, test_table, kcos);
     string serialized_str(buffer);
 
     EXPECT_EQ(serialized_len, 117);
@@ -38,7 +33,7 @@ TEST(BinarySerializer, serialize_deserialize)
     std::vector<KeyOpFieldsValuesTuple> deserialized_kcos;
     string db_name;
     string db_table;
-    BinarySerializer::deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
+    deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
     for (auto kco_ptr : kcos_ptrs)
     {
         deserialized_kcos.push_back(*kco_ptr);
@@ -56,12 +51,7 @@ TEST(BinarySerializer, serialize_overflow)
     values.push_back(std::make_pair("test_key", "test_value"));
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{"test_entry_key", "SET", values}};
-    EXPECT_THROW(BinarySerializer::serializeBuffer(
-                                                buffer,
-                                                sizeof(buffer),
-                                                "test_db",
-                                                "test_table",
-                                                kcos), runtime_error);
+    EXPECT_THROW(serializeBuffer(buffer, sizeof(buffer), "test_db", "test_table", kcos), runtime_error);
 }
 
 TEST(BinarySerializer, deserialize_overflow)
@@ -71,18 +61,13 @@ TEST(BinarySerializer, deserialize_overflow)
     values.push_back(std::make_pair("test_key", "test_value"));
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{"test_entry_key", "SET", values}};
-    int serialized_len = (int)BinarySerializer::serializeBuffer(
-                                                                buffer,
-                                                                sizeof(buffer),
-                                                                "test_db",
-                                                                "test_table",
-                                                                kcos);
+    size_t serialized_len = serializeBuffer(buffer, sizeof(buffer), "test_db", "test_table", kcos);
     string serialized_str(buffer);
 
     std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos_ptrs;
     string db_name;
     string db_table;
-    EXPECT_THROW(BinarySerializer::deserializeBuffer(buffer, serialized_len - 10, db_name, db_table, kcos_ptrs), runtime_error);
+    EXPECT_THROW(deserializeBuffer(buffer, serialized_len - 10, db_name, db_table, kcos_ptrs), runtime_error);
 }
 
 TEST(BinarySerializer, protocol_buffer)
@@ -101,12 +86,7 @@ TEST(BinarySerializer, protocol_buffer)
     values.push_back(std::make_pair(test_key, proto_buf_val));
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{test_entry_key, test_command, values}};
-    int serialized_len = (int)BinarySerializer::serializeBuffer(
-                                                                buffer,
-                                                                sizeof(buffer),
-                                                                test_db,
-                                                                test_table,
-                                                                kcos);
+    size_t serialized_len = serializeBuffer(buffer, sizeof(buffer), test_db, test_table, kcos);
     string serialized_str(buffer);
 
     EXPECT_EQ(serialized_len, 95);
@@ -115,7 +95,7 @@ TEST(BinarySerializer, protocol_buffer)
     std::vector<KeyOpFieldsValuesTuple> deserialized_kcos;
     string db_name;
     string db_table;
-    BinarySerializer::deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
+    deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
     for (auto kco_ptr : kcos_ptrs)
     {
         deserialized_kcos.push_back(*kco_ptr);

--- a/tests/binary_serializer_ut.cpp
+++ b/tests/binary_serializer_ut.cpp
@@ -26,7 +26,7 @@ TEST(BinarySerializer, serialize_deserialize)
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{test_entry_key, test_command, values},
         KeyOpFieldsValuesTuple{test_entry_key2, test_command2, std::vector<FieldValueTuple>{}}};
-    size_t serialized_len = serializeBuffer(buffer, sizeof(buffer), test_db, test_table, kcos);
+    size_t serialized_len = BinarySerializer::serializeBuffer(buffer, sizeof(buffer), test_db, test_table, kcos);
     string serialized_str(buffer);
 
     EXPECT_EQ(sizeof(size_t), 8); // the length test is only valid of sizeof(size_t) == 8
@@ -36,7 +36,7 @@ TEST(BinarySerializer, serialize_deserialize)
     std::vector<KeyOpFieldsValuesTuple> deserialized_kcos;
     string db_name;
     string db_table;
-    deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
+    BinarySerializer::deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
     for (auto kco_ptr : kcos_ptrs)
     {
         deserialized_kcos.push_back(*kco_ptr);
@@ -70,7 +70,7 @@ TEST(BinarySerializer, serialize_deserialize_sharedbuffer)
             KeyOpFieldsValuesTuple{test_entry_key2, test_command2, std::vector<FieldValueTuple>{}},
             KeyOpFieldsValuesTuple{test_iteration, "SET", {{test_iteration, test_iteration}}}
         };
-        BufferSlice slice = serializeSharedBuffer(test_db, test_table, kcos);
+        BinarySerializer::BufferSlice slice = BinarySerializer::serializeSharedBuffer(test_db, test_table, kcos);
 
         EXPECT_EQ(sizeof(size_t), 8); // the length test is only valid of sizeof(size_t) == 8
         EXPECT_EQ(slice.len, 159);
@@ -79,7 +79,7 @@ TEST(BinarySerializer, serialize_deserialize_sharedbuffer)
         std::vector<KeyOpFieldsValuesTuple> deserialized_kcos;
         string db_name;
         string db_table;
-        deserializeBuffer(slice.data, slice.len, db_name, db_table, kcos_ptrs);
+        BinarySerializer::deserializeBuffer(slice.data, slice.len, db_name, db_table, kcos_ptrs);
         for (auto kco_ptr : kcos_ptrs)
         {
             deserialized_kcos.push_back(*kco_ptr);
@@ -99,7 +99,7 @@ TEST(BinarySerializer, serialize_overflow)
     values.push_back(std::make_pair("test_key", "test_value"));
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{"test_entry_key", "SET", values}};
-    EXPECT_THROW(serializeBuffer(buffer, sizeof(buffer), "test_db", "test_table", kcos), runtime_error);
+    EXPECT_THROW(BinarySerializer::serializeBuffer(buffer, sizeof(buffer), "test_db", "test_table", kcos), runtime_error);
 }
 
 TEST(BinarySerializer, deserialize_overflow)
@@ -109,13 +109,13 @@ TEST(BinarySerializer, deserialize_overflow)
     values.push_back(std::make_pair("test_key", "test_value"));
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{"test_entry_key", "SET", values}};
-    size_t serialized_len = serializeBuffer(buffer, sizeof(buffer), "test_db", "test_table", kcos);
+    size_t serialized_len = BinarySerializer::serializeBuffer(buffer, sizeof(buffer), "test_db", "test_table", kcos);
     string serialized_str(buffer);
 
     std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> kcos_ptrs;
     string db_name;
     string db_table;
-    EXPECT_THROW(deserializeBuffer(buffer, serialized_len - 10, db_name, db_table, kcos_ptrs), runtime_error);
+    EXPECT_THROW(BinarySerializer::deserializeBuffer(buffer, serialized_len - 10, db_name, db_table, kcos_ptrs), runtime_error);
 }
 
 TEST(BinarySerializer, protocol_buffer)
@@ -134,7 +134,7 @@ TEST(BinarySerializer, protocol_buffer)
     values.push_back(std::make_pair(test_key, proto_buf_val));
     std::vector<KeyOpFieldsValuesTuple> kcos = std::vector<KeyOpFieldsValuesTuple>{
         KeyOpFieldsValuesTuple{test_entry_key, test_command, values}};
-    size_t serialized_len = serializeBuffer(buffer, sizeof(buffer), test_db, test_table, kcos);
+    size_t serialized_len = BinarySerializer::serializeBuffer(buffer, sizeof(buffer), test_db, test_table, kcos);
     string serialized_str(buffer);
 
     EXPECT_EQ(serialized_len, 95);
@@ -143,7 +143,7 @@ TEST(BinarySerializer, protocol_buffer)
     std::vector<KeyOpFieldsValuesTuple> deserialized_kcos;
     string db_name;
     string db_table;
-    deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
+    BinarySerializer::deserializeBuffer(buffer, serialized_len, db_name, db_table, kcos_ptrs);
     for (auto kco_ptr : kcos_ptrs)
     {
         deserialized_kcos.push_back(*kco_ptr);

--- a/tests/stringutility_ut.cpp
+++ b/tests/stringutility_ut.cpp
@@ -74,7 +74,7 @@ TEST(STRINGUTILITY, join)
 
 TEST(STRINGUTILITY, hex_to_binary)
 {
-    std::array<std::uint8_t, 5> a;
+    std::array<std::uint8_t, 5> a{};
 
     EXPECT_TRUE(swss::hex_to_binary("01020aff05", a.data(), a.size()));
     EXPECT_EQ(a, (std::array<std::uint8_t, 5>{0x1, 0x2, 0x0a, 0xff, 0x5}));


### PR DESCRIPTION
Fixed dubious undefined behavior stemming from unaligned writes to the serialization buffer. Add `serializeSharedBuffer` which uses a shared 16MB buffer instead of requiring the caller to have one available. This would make c-api code which uses these functions significantly more efficient. If we like these changes, we can also change ZmqClient to use the shared buffer functions. Every ZmqClient currently allocates its own 16MB serialization buffer, so doing this would save a nonnegligible amount of memory.

Also fixed a couple misc errors - uninitialized array in tests/stringutility_ut.cpp made tests fail to compile; ZMQ_NOBLOCK was deprecated 6 years ago and is now called ZMQ_DONTWAIT. I just noticed these while making changes to & testing BinarySerializer.

Related: https://github.com/sonic-net/sonic-swss-common/pull/915