### PR TITLE
Change eventd ZMQ endpoints from localhost to docker network

### DIFF
--- a/common/events_common.cpp
+++ b/common/events_common.cpp
@@ -7,10 +7,10 @@ int running_ut = 0;
  */
 #define CFG_VAL map_str_str_t::value_type
 const map_str_str_t cfg_default = {
-    CFG_VAL(XSUB_END_KEY, "tcp://127.0.0.1:5570"),
-    CFG_VAL(XPUB_END_KEY, "tcp://127.0.0.1:5571"),
-    CFG_VAL(REQ_REP_END_KEY, "tcp://127.0.0.1:5572"),
-    CFG_VAL(CAPTURE_END_KEY, "tcp://127.0.0.1:5573"),
+    CFG_VAL(XSUB_END_KEY, "tcp://240.127.1.1:5570"),
+    CFG_VAL(XPUB_END_KEY, "tcp://240.127.1.1:5571"),
+    CFG_VAL(REQ_REP_END_KEY, "tcp://240.127.1.1:5572"),
+    CFG_VAL(CAPTURE_END_KEY, "tcp://240.127.1.1:5573"),
     CFG_VAL(STATS_UPD_SECS, "5"),
     CFG_VAL(CACHE_MAX_CNT, "")
 };

--- a/tests/events_common_ut.cpp
+++ b/tests/events_common_ut.cpp
@@ -19,8 +19,8 @@ const char *test_cfg_data = "{\
 
 TEST(events_common, get_config)
 {
-    EXPECT_EQ(string("tcp://127.0.0.1:5570"), get_config(string(XSUB_END_KEY)));
-    EXPECT_EQ(string("tcp://127.0.0.1:5572"), get_config(string(REQ_REP_END_KEY)));
+    EXPECT_EQ(string("tcp://240.127.1.1:5570"), get_config(string(XSUB_END_KEY)));
+    EXPECT_EQ(string("tcp://240.127.1.1:5572"), get_config(string(REQ_REP_END_KEY)));
     EXPECT_EQ(string("5"), get_config(string(STATS_UPD_SECS)));
 
     ofstream tfile;
@@ -38,7 +38,7 @@ TEST(events_common, get_config)
     EXPECT_EQ(100, get_config_data(CACHE_MAX_CNT, 100));
 
     read_init_config(NULL);
-    EXPECT_EQ(string("tcp://127.0.0.1:5570"), get_config(string(XSUB_END_KEY)));
+    EXPECT_EQ(string("tcp://240.127.1.1:5570"), get_config(string(XSUB_END_KEY)));
 }
 
 void
@@ -73,7 +73,7 @@ TEST(events_common, send_recv)
     }
 #endif
 
-    char *path = "tcp://127.0.0.1:5570";
+    char *path = "tcp://240.127.1.1:5570";
     void *zmq_ctx = zmq_ctx_new();
     void *sock_p0 = zmq_socket (zmq_ctx, ZMQ_PAIR);
     EXPECT_EQ(0, zmq_connect (sock_p0, path));
@@ -108,7 +108,7 @@ TEST(events_common, send_recv_control_character)
     }
 #endif
 
-    char *path = "tcp://127.0.0.1:5570";
+    char *path = "tcp://240.127.1.1:5570";
     void *zmq_ctx = zmq_ctx_new();
     void *sock_p0 = zmq_socket (zmq_ctx, ZMQ_PAIR);
     EXPECT_EQ(0, zmq_connect (sock_p0, path));


### PR DESCRIPTION
Fixes sonic-net/sonic-buildimage#195591
Why I did it: 

For single-asic devices where host and docker containers share the same namespace, using localhost IP for ZMQ sockets worked as all containers were able to create a socket and connect to XSUB endpoint in order to publish events

However, in multi-asic devices, since certain dockers will have different network namespaces, we need to expose the ZMQ endpoint such that all dockers and host can connect to it in order to publish event. We can do this by using the docker network which is exposed to all containers.

With this change, we will be using docker network IP defined in docker.service.conf.