### PR TITLE
Rename events table to EVENTS

### DIFF
--- a/common/events_common.h
+++ b/common/events_common.h
@@ -127,7 +127,7 @@ typedef map<string, string> map_str_str_t;
  * Config that can be read from init_cfg
  */
 #define INIT_CFG_PATH "/etc/sonic/init_cfg.json"
-#define CFG_EVENTS_KEY "events"
+#define CFG_EVENTS_KEY "EVENTS"
 
 /* configurable entities' keys */
 /* zmq proxy's xsub & xpub end points */

--- a/tests/events_common_ut.cpp
+++ b/tests/events_common_ut.cpp
@@ -10,7 +10,7 @@
 using namespace std;
 
 const char *test_cfg_data = "{\
-\"events\" : {  \
+\"EVENTS\" : {  \
     \"xsub_path\": \"xsub_path\", \
     \"req_rep_path\": \"req_rep_path\" \
     }\


### PR DESCRIPTION
ADO: 29679395

Eventd ZMQ Configuration in init_cfg.json should follow other table's naming convention. Capitalizing events table name.