### PR TITLE
C API: improve performance by not memcpy-ing string DB values across ffi boundary 

### DIFF
--- a/common/c-api/consumerstatetable.cpp
+++ b/common/c-api/consumerstatetable.cpp
@@ -1,3 +1,4 @@
+#include <boost/numeric/conversion/cast.hpp>
 #include <cstdlib>
 #include <cstring>
 #include <deque>
@@ -10,6 +11,7 @@
 
 using namespace swss;
 using namespace std;
+using boost::numeric_cast;
 
 SWSSConsumerStateTable SWSSConsumerStateTable_new(SWSSDBConnector db, const char *tableName,
                                                   const int32_t *p_popBatchSize,

--- a/common/c-api/dbconnector.h
+++ b/common/c-api/dbconnector.h
@@ -29,11 +29,11 @@ void SWSSDBConnector_free(SWSSDBConnector db);
 // Returns 0 when key doesn't exist, 1 when key was deleted
 int8_t SWSSDBConnector_del(SWSSDBConnector db, const char *key);
 
-void SWSSDBConnector_set(SWSSDBConnector db, const char *key, const char *value);
+void SWSSDBConnector_set(SWSSDBConnector db, const char *key, SWSSStrRef value);
 
-// Returns NULL if key doesn't exist.
-// Result must be freed using free()
-char *SWSSDBConnector_get(SWSSDBConnector db, const char *key);
+// Returns NULL if key doesn't exist
+// Result must be freed using SWSSString_free()
+SWSSString SWSSDBConnector_get(SWSSDBConnector db, const char *key);
 
 // Returns 0 for false, 1 for true
 int8_t SWSSDBConnector_exists(SWSSDBConnector db, const char *key);
@@ -41,59 +41,22 @@ int8_t SWSSDBConnector_exists(SWSSDBConnector db, const char *key);
 // Returns 0 when key or field doesn't exist, 1 when field was deleted
 int8_t SWSSDBConnector_hdel(SWSSDBConnector db, const char *key, const char *field);
 
-void SWSSDBConnector_hset(SWSSDBConnector db, const char *key, const char *field,
-                          const char *value);
+void SWSSDBConnector_hset(SWSSDBConnector db, const char *key, const char *field, SWSSStrRef value);
 
-// Returns NULL if key or field doesn't exist.
-// Result must be freed using free()
-char *SWSSDBConnector_hget(SWSSDBConnector db, const char *key, const char *field);
+// Returns NULL if key or field doesn't exist
+// Result must be freed using SWSSString_free()
+SWSSString SWSSDBConnector_hget(SWSSDBConnector db, const char *key, const char *field);
 
-// Returns an empty map when the key doesn't exist.
-// Result array and all of its elements must be freed using free()
+// Returns an empty map when the key doesn't exist
+// Result array and all of its elements must be freed using appropriate free functions
 SWSSFieldValueArray SWSSDBConnector_hgetall(SWSSDBConnector db, const char *key);
 
 // Returns 0 when key or field doesn't exist, 1 when field exists
 int8_t SWSSDBConnector_hexists(SWSSDBConnector db, const char *key, const char *field);
 
-// std::vector<std::string> keys(const std::string &key);
-
-// std::pair<int, std::vector<std::string>> scan(int cursor = 0, const char
-// *match = "", uint32_t count = 10);
-
-// template<typename InputIterator>
-// void hmset(const std::string &key, InputIterator start, InputIterator stop);
-
-// void hmset(const std::unordered_map<std::string,
-// std::vector<std::pair<std::string, std::string>>>& multiHash);
-
-// std::shared_ptr<std::string> get(const std::string &key);
-
-// std::shared_ptr<std::string> hget(const std::string &key, const std::string
-// &field);
-
-// int64_t incr(const std::string &key);
-
-// int64_t decr(const std::string &key);
-
-// int64_t rpush(const std::string &list, const std::string &item);
-
-// std::shared_ptr<std::string> blpop(const std::string &list, int timeout);
-
-// void subscribe(const std::string &pattern);
-
-// void psubscribe(const std::string &pattern);
-
-// void punsubscribe(const std::string &pattern);
-
-// int64_t publish(const std::string &channel, const std::string &message);
-
-// void config_set(const std::string &key, const std::string &value);
-
 // Returns 1 on success, 0 on failure
 int8_t SWSSDBConnector_flushdb(SWSSDBConnector db);
 
-// std::map<std::string, std::map<std::string, std::map<std::string,
-// std::string>>> getall();
 #ifdef __cplusplus
 }
 #endif

--- a/common/c-api/producerstatetable.cpp
+++ b/common/c-api/producerstatetable.cpp
@@ -25,7 +25,7 @@ void SWSSProducerStateTable_setBuffered(SWSSProducerStateTable tbl, uint8_t buff
 
 void SWSSProducerStateTable_set(SWSSProducerStateTable tbl, const char *key,
                                 SWSSFieldValueArray values) {
-    SWSSTry(((ProducerStateTable *)tbl)->set(string(key), takeFieldValueArray(values)));
+    SWSSTry(((ProducerStateTable *)tbl)->set(string(key), takeFieldValueArray(std::move(values))));
 }
 
 void SWSSProducerStateTable_del(SWSSProducerStateTable tbl, const char *key) {

--- a/common/c-api/producerstatetable.h
+++ b/common/c-api/producerstatetable.h
@@ -22,11 +22,6 @@ void SWSSProducerStateTable_set(SWSSProducerStateTable tbl, const char *key, SWS
 
 void SWSSProducerStateTable_del(SWSSProducerStateTable tbl, const char *key);
 
-// Batched version of set() and del().
-// virtual void set(const std::vector<KeyOpFieldsValuesTuple>& values);
-
-// virtual void del(const std::vector<std::string>& keys);
-
 void SWSSProducerStateTable_flush(SWSSProducerStateTable tbl);
 
 int64_t SWSSProducerStateTable_count(SWSSProducerStateTable tbl);

--- a/common/c-api/subscriberstatetable.cpp
+++ b/common/c-api/subscriberstatetable.cpp
@@ -1,3 +1,4 @@
+#include <boost/numeric/conversion/cast.hpp>
 #include <cstdlib>
 #include <cstring>
 #include <deque>
@@ -11,6 +12,7 @@
 
 using namespace swss;
 using namespace std;
+using boost::numeric_cast;
 
 SWSSSubscriberStateTable SWSSSubscriberStateTable_new(SWSSDBConnector db, const char *tableName,
                                                       const int32_t *p_popBatchSize,

--- a/common/c-api/util.cpp
+++ b/common/c-api/util.cpp
@@ -1,3 +1,33 @@
 #include "util.h"
 
+using namespace swss;
+
 bool swss::cApiTestingDisableAbort = false;
+
+SWSSString SWSSString_new(const char *data, uint64_t length) {
+    SWSSTry(return makeString(std::string(data, length)));
+}
+
+SWSSString SWSSString_new_c_str(const char *c_str) {
+    SWSSTry(return makeString(std::string(c_str)));
+}
+
+const char *SWSSStrRef_c_str(SWSSStrRef s) {
+    SWSSTry(return ((std::string *)s)->c_str());
+}
+
+uint64_t SWSSStrRef_length(SWSSStrRef s) {
+    SWSSTry(return ((std::string *)s)->length());
+}
+
+void SWSSString_free(SWSSString s) {
+    SWSSTry(delete (std::string *)s);
+}
+
+void SWSSFieldValueArray_free(SWSSFieldValueArray arr) {
+    SWSSTry(delete[] arr.data);
+}
+
+void SWSSKeyOpFieldValuesArray_free(SWSSKeyOpFieldValuesArray kfvs) {
+    SWSSTry(delete[] kfvs.data);
+}

--- a/common/c-api/util.cpp
+++ b/common/c-api/util.cpp
@@ -5,7 +5,7 @@ using namespace swss;
 bool swss::cApiTestingDisableAbort = false;
 
 SWSSString SWSSString_new(const char *data, uint64_t length) {
-    SWSSTry(return makeString(std::string(data, length)));
+    SWSSTry(return makeString(std::string(data, numeric_cast<std::string::size_type>(length))));
 }
 
 SWSSString SWSSString_new_c_str(const char *c_str) {

--- a/common/c-api/zmqclient.cpp
+++ b/common/c-api/zmqclient.cpp
@@ -24,9 +24,9 @@ void SWSSZmqClient_connect(SWSSZmqClient zmqc) {
 }
 
 void SWSSZmqClient_sendMsg(SWSSZmqClient zmqc, const char *dbName, const char *tableName,
-                           const SWSSKeyOpFieldValuesArray *arr) {
+                           SWSSKeyOpFieldValuesArray arr) {
     SWSSTry({
-        vector<KeyOpFieldsValuesTuple> kcos = takeKeyOpFieldValuesArray(*arr);
+        vector<KeyOpFieldsValuesTuple> kcos = takeKeyOpFieldValuesArray(arr);
         size_t bufSize = BinarySerializer::serializedSize(dbName, tableName, kcos);
         vector<char> v(bufSize);
         ((ZmqClient *)zmqc)

--- a/common/c-api/zmqclient.h
+++ b/common/c-api/zmqclient.h
@@ -21,7 +21,7 @@ int8_t SWSSZmqClient_isConnected(SWSSZmqClient zmqc);
 void SWSSZmqClient_connect(SWSSZmqClient zmqc);
 
 void SWSSZmqClient_sendMsg(SWSSZmqClient zmqc, const char *dbName, const char *tableName,
-                           const SWSSKeyOpFieldValuesArray *kcos);
+                           SWSSKeyOpFieldValuesArray kcos);
 
 #ifdef __cplusplus
 }

--- a/common/c-api/zmqconsumerstatetable.cpp
+++ b/common/c-api/zmqconsumerstatetable.cpp
@@ -1,3 +1,4 @@
+#include <boost/numeric/conversion/cast.hpp>
 #include "../zmqconsumerstatetable.h"
 #include "../table.h"
 #include "util.h"
@@ -7,6 +8,7 @@
 
 using namespace swss;
 using namespace std;
+using boost::numeric_cast;
 
 // Pass NULL for popBatchSize and/or pri to use the default values
 SWSSZmqConsumerStateTable SWSSZmqConsumerStateTable_new(SWSSDBConnector db, const char *tableName,

--- a/common/c-api/zmqproducerstatetable.cpp
+++ b/common/c-api/zmqproducerstatetable.cpp
@@ -1,8 +1,11 @@
+#include <boost/numeric/conversion/cast.hpp>
+
 #include "zmqproducerstatetable.h"
 #include "../zmqproducerstatetable.h"
 
 using namespace std;
 using namespace swss;
+using boost::numeric_cast;
 
 SWSSZmqProducerStateTable SWSSZmqProducerStateTable_new(SWSSDBConnector db, const char *tableName,
                                                         SWSSZmqClient zmqc, uint8_t dbPersistence) {


### PR DESCRIPTION
This introduces a couple of new FFI types, representing owned C++ strings and arrays. We use those owned strings for database values, so they do not need to be memcpy'd across ffi boundaries. This is in response to Riff's concerns that database values which hamgrd will be reading may be large and expensive to memcpy.

Partner pr to https://github.com/sonic-net/sonic-dash-ha/pull/11