### PR TITLE
Fix unit test for goext

### DIFF
--- a/goext/Makefile
+++ b/goext/Makefile
@@ -17,7 +17,6 @@ all:
 	$(SWIG) $(SWIG_FLAG) -I/usr/include/swss/ swsscommon.i
 
 check:
-	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) build
 	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test
 
 clean:


### PR DESCRIPTION
#### Why I did it
https://github.com/sonic-net/sonic-swss-common/pull/937
PR checker is blocked by goext build

#### How I did it
Remove go build, and keep go test to run unit test.

#### How to verify it
Pass all UT and E2E test cases.