### PR TITLE
Added new PORT_OPERR_TABLE table in STATE_DB

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -479,6 +479,7 @@ namespace swss {
 #define STATE_ACL_STAGE_CAPABILITY_TABLE_NAME       "ACL_STAGE_CAPABILITY_TABLE"
 #define STATE_PBH_CAPABILITIES_TABLE_NAME           "PBH_CAPABILITIES"
 #define STATE_PORT_TABLE_NAME                       "PORT_TABLE"
+#define STATE_PORT_OPER_ERR_TABLE_NAME              "PORT_OPERR_TABLE"
 #define STATE_LAG_TABLE_NAME                        "LAG_TABLE"
 #define STATE_VLAN_TABLE_NAME                       "VLAN_TABLE"
 #define STATE_VLAN_MEMBER_TABLE_NAME                "VLAN_MEMBER_TABLE"


### PR DESCRIPTION
Added new PORT_OPERR_TABLE table in STATE_DB

This table will be updated by OA whenever port oper down notification reports [sai_port_error_status_t](https://github.com/opencomputeproject/SAI/blob/8b8fa85178383ae0a8bf1a64279934a6b3087837/inc/saiport.h#L84) errors