### PR TITLE
C-api: refine interface on Selectable classes

### DIFF
--- a/common/c-api/consumerstatetable.cpp
+++ b/common/c-api/consumerstatetable.cpp
@@ -32,3 +32,12 @@ SWSSKeyOpFieldValuesArray SWSSConsumerStateTable_pops(SWSSConsumerStateTable tbl
         return makeKeyOpFieldValuesArray(vkco);
     });
 }
+
+uint32_t SWSSConsumerStateTable_getFd(SWSSConsumerStateTable tbl) {
+    SWSSTry(return numeric_cast<uint32_t>(((ConsumerStateTable *)tbl)->getFd()));
+}
+
+SWSSSelectResult SWSSConsumerStateTable_readData(SWSSConsumerStateTable tbl, uint32_t timeout_ms,
+                                                 uint8_t interrupt_on_signal) {
+    SWSSTry(return selectOne((ConsumerStateTable *)tbl, timeout_ms, interrupt_on_signal));
+}

--- a/common/c-api/consumerstatetable.h
+++ b/common/c-api/consumerstatetable.h
@@ -21,6 +21,17 @@ void SWSSConsumerStateTable_free(SWSSConsumerStateTable tbl);
 // Result array and all of its members must be freed using free()
 SWSSKeyOpFieldValuesArray SWSSConsumerStateTable_pops(SWSSConsumerStateTable tbl);
 
+// Return the underlying fd for polling/selecting on.
+// Callers must NOT read/write on fd, it may only be used for epoll or similar.
+// After the fd becomes readable, SWSSConsumerStateTable_readData must be used to
+// reset the fd and read data into internal data structures.
+uint32_t SWSSConsumerStateTable_getFd(SWSSConsumerStateTable tbl);
+
+// Block until data is available to read or until a timeout elapses.
+// A timeout of 0 means the call will return immediately.
+SWSSSelectResult SWSSConsumerStateTable_readData(SWSSConsumerStateTable tbl, uint32_t timeout_ms,
+                                                 uint8_t interrupt_on_signal);
+
 #ifdef __cplusplus
 }
 #endif

--- a/common/c-api/subscriberstatetable.cpp
+++ b/common/c-api/subscriberstatetable.cpp
@@ -34,19 +34,12 @@ SWSSKeyOpFieldValuesArray SWSSSubscriberStateTable_pops(SWSSSubscriberStateTable
     });
 }
 
-uint8_t SWSSSubscriberStateTable_hasData(SWSSSubscriberStateTable tbl) {
-    SWSSTry(return ((SubscriberStateTable *)tbl)->hasData() ? 1 : 0);
-}
-
-uint8_t SWSSSubscriberStateTable_hasCachedData(SWSSSubscriberStateTable tbl) {
-    SWSSTry(return ((SubscriberStateTable *)tbl)->hasCachedData() ? 1 : 0);
-}
-
-uint8_t SWSSSubscriberStateTable_initializedWithData(SWSSSubscriberStateTable tbl) {
-    SWSSTry(return ((SubscriberStateTable *)tbl)->initializedWithData() ? 1 : 0);
+uint32_t SWSSSubscriberStateTable_getFd(SWSSSubscriberStateTable tbl) {
+    SWSSTry(return numeric_cast<uint32_t>(((SubscriberStateTable *)tbl)->getFd()));
 }
 
 SWSSSelectResult SWSSSubscriberStateTable_readData(SWSSSubscriberStateTable tbl,
-                                                   uint32_t timeout_ms) {
-    SWSSTry(return selectOne((SubscriberStateTable *)tbl, timeout_ms));
+                                                   uint32_t timeout_ms,
+                                                   uint8_t interrupt_on_signal) {
+    SWSSTry(return selectOne((SubscriberStateTable *)tbl, timeout_ms, interrupt_on_signal));
 }

--- a/common/c-api/subscriberstatetable.h
+++ b/common/c-api/subscriberstatetable.h
@@ -22,19 +22,17 @@ void SWSSSubscriberStateTable_free(SWSSSubscriberStateTable tbl);
 // Result array and all of its members must be freed using free()
 SWSSKeyOpFieldValuesArray SWSSSubscriberStateTable_pops(SWSSSubscriberStateTable tbl);
 
-// Returns 0 for false, 1 for true
-uint8_t SWSSSubscriberStateTable_hasData(SWSSSubscriberStateTable tbl);
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSSubscriberStateTable_hasCachedData(SWSSSubscriberStateTable tbl);
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSSubscriberStateTable_initializedWithData(SWSSSubscriberStateTable tbl);
+// Return the underlying fd for polling/selecting on.
+// Callers must NOT read/write on fd, it may only be used for epoll or similar.
+// After the fd becomes readable, SWSSSubscriberStateTable_readData must be used to
+// reset the fd and read data into internal data structures.
+uint32_t SWSSSubscriberStateTable_getFd(SWSSSubscriberStateTable tbl);
 
 // Block until data is available to read or until a timeout elapses.
 // A timeout of 0 means the call will return immediately.
 SWSSSelectResult SWSSSubscriberStateTable_readData(SWSSSubscriberStateTable tbl,
-                                                   uint32_t timeout_ms);
+                                                   uint32_t timeout_ms,
+                                                   uint8_t interrupt_on_sugnal);
 
 #ifdef __cplusplus
 }

--- a/common/c-api/util.h
+++ b/common/c-api/util.h
@@ -29,9 +29,14 @@ typedef struct {
     const SWSSKeyOpFieldValues *data;
 } SWSSKeyOpFieldValuesArray;
 
+// FFI version of swss::Select::{OBJECT, TIMEOUT, SIGNALINT}.
+// swss::Select::ERROR is left out because errors are handled separately
 typedef enum {
+    // Data is available in the object
     SWSSSelectResult_DATA = 0,
+    // Timed out waiting for data
     SWSSSelectResult_TIMEOUT = 1,
+    // Waiting was interrupted by a signal
     SWSSSelectResult_SIGNAL = 2,
 } SWSSSelectResult;
 
@@ -74,11 +79,12 @@ extern bool cApiTestingDisableAbort;
         }                                                                                          \
     }
 
-static inline SWSSSelectResult selectOne(swss::Selectable *s, uint32_t timeout_ms) {
+static inline SWSSSelectResult selectOne(swss::Selectable *s, uint32_t timeout_ms,
+                                         uint8_t interrupt_on_signal) {
     Select select;
     Selectable *sOut;
     select.addSelectable(s);
-    int ret = select.select(&sOut, numeric_cast<int>(timeout_ms));
+    int ret = select.select(&sOut, numeric_cast<int>(timeout_ms), interrupt_on_signal);
     switch (ret) {
     case Select::OBJECT:
         return SWSSSelectResult_DATA;

--- a/common/c-api/zmqconsumerstatetable.cpp
+++ b/common/c-api/zmqconsumerstatetable.cpp
@@ -3,6 +3,7 @@
 #include "util.h"
 #include "zmqconsumerstatetable.h"
 #include "zmqserver.h"
+#include <boost/numeric/conversion/cast.hpp>
 
 using namespace swss;
 using namespace std;
@@ -32,24 +33,14 @@ SWSSKeyOpFieldValuesArray SWSSZmqConsumerStateTable_pops(SWSSZmqConsumerStateTab
     });
 }
 
+uint32_t SWSSZmqConsumerStateTable_getFd(SWSSZmqConsumerStateTable tbl) {
+    SWSSTry(return numeric_cast<uint32_t>(((ZmqConsumerStateTable *)tbl)->getFd()));
+}
+
 SWSSSelectResult SWSSZmqConsumerStateTable_readData(SWSSZmqConsumerStateTable tbl,
-                                                    uint32_t timeout_ms) {
-    SWSSTry(return selectOne((ZmqConsumerStateTable *)tbl, timeout_ms));
-}
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSZmqConsumerStateTable_hasData(SWSSZmqConsumerStateTable tbl) {
-    SWSSTry(return ((ZmqConsumerStateTable *)tbl)->hasData() ? 1 : 0);
-}
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSZmqConsumerStateTable_hasCachedData(SWSSZmqConsumerStateTable tbl) {
-    SWSSTry(return ((ZmqConsumerStateTable *)tbl)->hasCachedData() ? 1 : 0);
-}
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSZmqConsumerStateTable_initializedWithData(SWSSZmqConsumerStateTable tbl) {
-    SWSSTry(return ((ZmqConsumerStateTable *)tbl)->initializedWithData() ? 1 : 0);
+                                                    uint32_t timeout_ms,
+                                                    uint8_t interrupt_on_signal) {
+    SWSSTry(return selectOne((ZmqConsumerStateTable *)tbl, timeout_ms, interrupt_on_signal));
 }
 
 const struct SWSSDBConnectorOpaque *

--- a/common/c-api/zmqconsumerstatetable.h
+++ b/common/c-api/zmqconsumerstatetable.h
@@ -24,19 +24,17 @@ void SWSSZmqConsumerStateTable_free(SWSSZmqConsumerStateTable tbl);
 // Result array and all of its members must be freed using free()
 SWSSKeyOpFieldValuesArray SWSSZmqConsumerStateTable_pops(SWSSZmqConsumerStateTable tbl);
 
+// Return the underlying fd for polling/selecting on.
+// Callers must NOT read/write on fd, it may only be used for epoll or similar.
+// After the fd becomes readable, SWSSZmqConsumerStateTable_readData must be used to
+// reset the fd and read data into internal data structures.
+uint32_t SWSSZmqConsumerStateTable_getFd(SWSSZmqConsumerStateTable tbl);
+
 // Block until data is available to read or until a timeout elapses.
 // A timeout of 0 means the call will return immediately.
 SWSSSelectResult SWSSZmqConsumerStateTable_readData(SWSSZmqConsumerStateTable tbl,
-                                                    uint32_t timeout_ms);
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSZmqConsumerStateTable_hasData(SWSSZmqConsumerStateTable tbl);
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSZmqConsumerStateTable_hasCachedData(SWSSZmqConsumerStateTable tbl);
-
-// Returns 0 for false, 1 for true
-uint8_t SWSSZmqConsumerStateTable_initializedWithData(SWSSZmqConsumerStateTable tbl);
+                                                    uint32_t timeout_ms,
+                                                    uint8_t interrupt_on_signal);
 
 const struct SWSSDBConnectorOpaque *
 SWSSZmqConsumerStateTable_getDbConnector(SWSSZmqConsumerStateTable tbl);

--- a/tests/c_api_ut.cpp
+++ b/tests/c_api_ut.cpp
@@ -94,6 +94,8 @@ TEST(c_api, ConsumerProducerStateTables) {
     SWSSProducerStateTable pst = SWSSProducerStateTable_new(db, "mytable");
     SWSSConsumerStateTable cst = SWSSConsumerStateTable_new(db, "mytable", nullptr, nullptr);
 
+    SWSSConsumerStateTable_getFd(cst);
+
     SWSSKeyOpFieldValuesArray arr = SWSSConsumerStateTable_pops(cst);
     ASSERT_EQ(arr.len, 0);
     freeKeyOpFieldValuesArray(arr);
@@ -169,6 +171,8 @@ TEST(c_api, SubscriberStateTable) {
     SWSSDBConnector db = SWSSDBConnector_new_named("TEST_DB", 1000, true);
     SWSSSubscriberStateTable sst = SWSSSubscriberStateTable_new(db, "mytable", nullptr, nullptr);
 
+    SWSSSubscriberStateTable_getFd(sst);
+
     EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_TIMEOUT);
     SWSSKeyOpFieldValuesArray arr = SWSSSubscriberStateTable_pops(sst);
     EXPECT_EQ(arr.len, 0);
@@ -206,6 +210,8 @@ TEST(c_api, ZmqConsumerProducerStateTable) {
     SWSSZmqProducerStateTable pst = SWSSZmqProducerStateTable_new(db, "mytable", cli, false);
     SWSSZmqConsumerStateTable cst =
         SWSSZmqConsumerStateTable_new(db, "mytable", srv, nullptr, nullptr);
+
+    SWSSZmqConsumerStateTable_getFd(cst);
 
     ASSERT_EQ(SWSSZmqConsumerStateTable_getDbConnector(cst), db);
 

--- a/tests/c_api_ut.cpp
+++ b/tests/c_api_ut.cpp
@@ -168,23 +168,21 @@ TEST(c_api, SubscriberStateTable) {
     SWSSDBConnector db = SWSSDBConnector_new_named("TEST_DB", 1000, true);
     SWSSSubscriberStateTable sst = SWSSSubscriberStateTable_new(db, "mytable", nullptr, nullptr);
 
-    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300), SWSSSelectResult_TIMEOUT);
-    EXPECT_FALSE(SWSSSubscriberStateTable_hasData(sst));
+    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_TIMEOUT);
     SWSSKeyOpFieldValuesArray arr = SWSSSubscriberStateTable_pops(sst);
     EXPECT_EQ(arr.len, 0);
     freeKeyOpFieldValuesArray(arr);
 
     SWSSDBConnector_hset(db, "mytable:mykey", "myfield", "myvalue");
-    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300), SWSSSelectResult_DATA);
-    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300), SWSSSelectResult_TIMEOUT);
-    EXPECT_TRUE(SWSSSubscriberStateTable_hasData(sst));
+    ASSERT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_DATA);
+    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_TIMEOUT);
 
     arr = SWSSSubscriberStateTable_pops(sst);
+    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_TIMEOUT);
     vector<KeyOpFieldsValuesTuple> kfvs = takeKeyOpFieldValuesArray(arr);
     sortKfvs(kfvs);
     freeKeyOpFieldValuesArray(arr);
 
-    EXPECT_FALSE(SWSSSubscriberStateTable_hasData(sst));
     ASSERT_EQ(kfvs.size(), 1);
     EXPECT_EQ(kfvKey(kfvs[0]), "mykey");
     EXPECT_EQ(kfvOp(kfvs[0]), "SET");
@@ -213,9 +211,6 @@ TEST(c_api, ZmqConsumerProducerStateTable) {
 
     ASSERT_EQ(SWSSZmqConsumerStateTable_getDbConnector(cst), db);
 
-    EXPECT_FALSE(SWSSZmqConsumerStateTable_hasData(cst));
-    EXPECT_FALSE(SWSSZmqConsumerStateTable_hasCachedData(cst));
-    EXPECT_FALSE(SWSSZmqConsumerStateTable_initializedWithData(cst));
     SWSSKeyOpFieldValuesArray arr = SWSSZmqConsumerStateTable_pops(cst);
     ASSERT_EQ(arr.len, 0);
     freeKeyOpFieldValuesArray(arr);
@@ -247,13 +242,10 @@ TEST(c_api, ZmqConsumerProducerStateTable) {
         else
             SWSSZmqClient_sendMsg(cli, "TEST_DB", "mytable", &arr);
 
-        ASSERT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500), SWSSSelectResult_DATA);
-        EXPECT_TRUE(SWSSZmqConsumerStateTable_hasData(cst));
-        EXPECT_TRUE(SWSSZmqConsumerStateTable_hasCachedData(cst));
+        ASSERT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_DATA);
+        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_TIMEOUT);
         arr = SWSSZmqConsumerStateTable_pops(cst);
-        EXPECT_FALSE(SWSSZmqConsumerStateTable_hasData(cst));
-        EXPECT_FALSE(SWSSZmqConsumerStateTable_hasCachedData(cst));
-        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500), SWSSSelectResult_TIMEOUT);
+        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_TIMEOUT);
 
         vector<KeyOpFieldsValuesTuple> kfvs = takeKeyOpFieldValuesArray(arr);
         sortKfvs(kfvs);
@@ -276,7 +268,6 @@ TEST(c_api, ZmqConsumerProducerStateTable) {
         EXPECT_EQ(fieldValues1[0].first, "myfield3");
         EXPECT_EQ(fieldValues1[0].second, "myvalue3");
 
-        EXPECT_FALSE(SWSSZmqConsumerStateTable_hasData(cst));
         arr = SWSSZmqConsumerStateTable_pops(cst);
         ASSERT_EQ(arr.len, 0);
         freeKeyOpFieldValuesArray(arr);
@@ -291,13 +282,9 @@ TEST(c_api, ZmqConsumerProducerStateTable) {
         else
             SWSSZmqClient_sendMsg(cli, "TEST_DB", "mytable", &arr);
 
-        ASSERT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500), SWSSSelectResult_DATA);
-        EXPECT_TRUE(SWSSZmqConsumerStateTable_hasData(cst));
-        EXPECT_TRUE(SWSSZmqConsumerStateTable_hasCachedData(cst));
+        ASSERT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_DATA);
         arr = SWSSZmqConsumerStateTable_pops(cst);
-        EXPECT_FALSE(SWSSZmqConsumerStateTable_hasData(cst));
-        EXPECT_FALSE(SWSSZmqConsumerStateTable_hasCachedData(cst));
-        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500), SWSSSelectResult_TIMEOUT);
+        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_TIMEOUT);
 
         kfvs = takeKeyOpFieldValuesArray(arr);
         sortKfvs(kfvs);

--- a/tests/c_api_ut.cpp
+++ b/tests/c_api_ut.cpp
@@ -110,6 +110,7 @@ TEST(c_api, ConsumerProducerStateTables) {
     values.len = 1;
     SWSSProducerStateTable_set(pst, "mykey2", values);
 
+    ASSERT_EQ(SWSSConsumerStateTable_readData(cst, 300, true), SWSSSelectResult_DATA);
     arr = SWSSConsumerStateTable_pops(cst);
     vector<KeyOpFieldsValuesTuple> kfvs = takeKeyOpFieldValuesArray(arr);
     sortKfvs(kfvs);
@@ -131,7 +132,7 @@ TEST(c_api, ConsumerProducerStateTables) {
     ASSERT_EQ(fieldValues1.size(), 1);
     EXPECT_EQ(fieldValues1[0].first, "myfield3");
     EXPECT_EQ(fieldValues1[0].second, "myvalue3");
-
+  
     arr = SWSSConsumerStateTable_pops(cst);
     EXPECT_EQ(arr.len, 0);
     freeKeyOpFieldValuesArray(arr);
@@ -175,10 +176,7 @@ TEST(c_api, SubscriberStateTable) {
 
     SWSSDBConnector_hset(db, "mytable:mykey", "myfield", "myvalue");
     ASSERT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_DATA);
-    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_TIMEOUT);
-
     arr = SWSSSubscriberStateTable_pops(sst);
-    EXPECT_EQ(SWSSSubscriberStateTable_readData(sst, 300, true), SWSSSelectResult_TIMEOUT);
     vector<KeyOpFieldsValuesTuple> kfvs = takeKeyOpFieldValuesArray(arr);
     sortKfvs(kfvs);
     freeKeyOpFieldValuesArray(arr);
@@ -242,10 +240,8 @@ TEST(c_api, ZmqConsumerProducerStateTable) {
         else
             SWSSZmqClient_sendMsg(cli, "TEST_DB", "mytable", &arr);
 
-        ASSERT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_DATA);
-        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_TIMEOUT);
+        ASSERT_EQ(SWSSZmqConsumerStateTable_readData(cst, 1500, true), SWSSSelectResult_DATA);
         arr = SWSSZmqConsumerStateTable_pops(cst);
-        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_TIMEOUT);
 
         vector<KeyOpFieldsValuesTuple> kfvs = takeKeyOpFieldValuesArray(arr);
         sortKfvs(kfvs);
@@ -284,7 +280,6 @@ TEST(c_api, ZmqConsumerProducerStateTable) {
 
         ASSERT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_DATA);
         arr = SWSSZmqConsumerStateTable_pops(cst);
-        EXPECT_EQ(SWSSZmqConsumerStateTable_readData(cst, 500, true), SWSSSelectResult_TIMEOUT);
 
         kfvs = takeKeyOpFieldValuesArray(arr);
         sortKfvs(kfvs);


### PR DESCRIPTION
Previously, methods like hasData/hasCachedData were exposed through the FFI, but they are only useful for swss::Select which is not exposed, so those were deleted. Methods *_getFd were added so that ffi code may select on those fds separately from swss::Select (we need this in Rust for tokio::AsyncFd). Comments were added to better explain the intended use - Either call readData with a timeout to block in place, or use getFd to select on the fd and then call readData with a zero timeout to reset the fd.