### PR TITLE
[zmq] add proxy mode to the ZmqServer

### DIFF
--- a/common/zmqclient.cpp
+++ b/common/zmqclient.cpp
@@ -9,6 +9,7 @@
 #include <system_error>
 #include <zmq.h>
 #include "zmqclient.h"
+#include "zmqserver.h"
 #include "binaryserializer.h"
 
 using namespace std;
@@ -113,27 +114,10 @@ void ZmqClient::connect()
     m_connected = true;
 }
 
-void ZmqClient::sendMsg(
-        const std::string& dbName,
-        const std::string& tableName,
-        const std::vector<KeyOpFieldsValuesTuple>& kcos,
-        std::vector<char>& sendbuffer)
+
+void ZmqClient::sendRaw(const char* buffer, size_t size)
 {
-    int serializedlen = (int)BinarySerializer::serializeBuffer(
-                                                        sendbuffer.data(),
-                                                        sendbuffer.size(),
-                                                        dbName,
-                                                        tableName,
-                                                        kcos);
-
-    if (serializedlen >= MQ_RESPONSE_MAX_COUNT)
-    {
-        SWSS_LOG_THROW("ZmqClient sendMsg message was too big (buffer size %d bytes, got %d), reduce the message size, message DROPPED",
-                MQ_RESPONSE_MAX_COUNT,
-                serializedlen);
-    }
-
-    SWSS_LOG_DEBUG("sending: %d", serializedlen);
+    SWSS_LOG_DEBUG("sending: %zu", size);
     int zmq_err = 0;
     int retry_delay = 10;
     int rc = 0;
@@ -144,12 +128,12 @@ void ZmqClient::sendMsg(
             std::lock_guard<std::mutex> lock(m_socketMutex);
 
             // Use none block mode to use all bandwidth: http://api.zeromq.org/2-1%3Azmq-send
-            rc = zmq_send(m_socket, sendbuffer.data(), serializedlen, ZMQ_NOBLOCK);
+            rc = zmq_send(m_socket, buffer, size, ZMQ_NOBLOCK);
         }
 
         if (rc >= 0)
         {
-            SWSS_LOG_DEBUG("zmq sended %d bytes", serializedlen);
+            SWSS_LOG_DEBUG("zmq sended %zu bytes", size);
             return;
         }
 
@@ -192,9 +176,32 @@ void ZmqClient::sendMsg(
     }
 
     // failed after retry
-    auto message =  "zmq send failed, endpoint: " + m_endpoint + ", zmqerrno: " + to_string(zmq_err) + ":" + zmq_strerror(zmq_err) + ", msg length:" + to_string(serializedlen);
+    auto message =  "zmq send failed, endpoint: " + m_endpoint + ", zmqerrno: " + to_string(zmq_err) + ":" + zmq_strerror(zmq_err) + ", msg length:" + to_string(size);
     SWSS_LOG_ERROR("%s", message.c_str());
     throw system_error(make_error_code(errc::io_error), message);
+}
+
+void ZmqClient::sendMsg(
+        const std::string& dbName,
+        const std::string& tableName,
+        const std::vector<KeyOpFieldsValuesTuple>& kcos,
+        std::vector<char>& sendbuffer)
+{
+    int serializedlen = (int)BinarySerializer::serializeBuffer(
+                                                        sendbuffer.data(),
+                                                        sendbuffer.size(),
+                                                        dbName,
+                                                        tableName,
+                                                        kcos);
+
+    if (serializedlen >= MQ_RESPONSE_MAX_COUNT)
+    {
+        SWSS_LOG_THROW("ZmqClient sendMsg message was too big (buffer size %d bytes, got %d), reduce the message size, message DROPPED",
+                MQ_RESPONSE_MAX_COUNT,
+                serializedlen);
+    }
+
+    sendRaw(sendbuffer.data(), serializedlen);
 }
 
 }

--- a/common/zmqclient.h
+++ b/common/zmqclient.h
@@ -5,7 +5,7 @@
 #include <queue>
 #include <thread> 
 #include <mutex> 
-#include "zmqserver.h"
+#include "table.h"
 
 namespace swss {
 
@@ -24,6 +24,8 @@ public:
                  const std::string& tableName,
                  const std::vector<KeyOpFieldsValuesTuple>& kcos,
                  std::vector<char>& sendbuffer);
+
+    void sendRaw(const char* buffer, size_t size);
 private:
     void initialize(const std::string& endpoint, const std::string& vrf);
 

--- a/common/zmqconsumerstatetable.cpp
+++ b/common/zmqconsumerstatetable.cpp
@@ -39,6 +39,11 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
     SWSS_LOG_DEBUG("ZmqConsumerStateTable ctor tableName: %s", tableName.c_str());
 }
 
+ZmqConsumerStateTable::~ZmqConsumerStateTable()
+{
+    m_zmqServer.unregisterMessageHandler(m_db->getDbName(), getTableName());
+}
+
 void ZmqConsumerStateTable::handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos)
 {
     for (auto kco : kcos)

--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -19,6 +19,7 @@ public:
     static constexpr int DEFAULT_POP_BATCH_SIZE = 128;
 
     ZmqConsumerStateTable(DBConnector *db, const std::string &tableName, ZmqServer &zmqServer, int popBatchSize = DEFAULT_POP_BATCH_SIZE, int pri = 0, bool dbPersistence = false);
+    ~ZmqConsumerStateTable();
 
     /* Get multiple pop elements */
     void pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string &prefix = EMPTY_PREFIX);


### PR DESCRIPTION
* ZmqServer can now work as a proxy server (using ZmqClient to send unprocessed messages)
* add sendRaw() method to the ZmqClient to avoid unnecessary serialization