### PR TITLE
Add field for bulk chunk size in flex counter

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -285,6 +285,7 @@ namespace swss {
 #define LUA_PLUGIN_TYPE                 "LUA_PLUGIN_TYPE"
 #define SAI_OBJECT_TYPE                 "SAI_OBJECT_TYPE"
 
+#define BULK_CHUNK_SIZE_FIELD               "BULK_CHUNK_SIZE"
 #define POLL_INTERVAL_FIELD                 "POLL_INTERVAL"
 #define STATS_MODE_FIELD                    "STATS_MODE"
 #define STATS_MODE_READ                     "STATS_MODE_READ"

--- a/common/schema.h
+++ b/common/schema.h
@@ -286,6 +286,7 @@ namespace swss {
 #define SAI_OBJECT_TYPE                 "SAI_OBJECT_TYPE"
 
 #define BULK_CHUNK_SIZE_FIELD               "BULK_CHUNK_SIZE"
+#define BULK_CHUNK_SIZE_PER_PREFIX_FIELD    "BULK_CHUNK_SIZE_PER_PREFIX"
 #define POLL_INTERVAL_FIELD                 "POLL_INTERVAL"
 #define STATS_MODE_FIELD                    "STATS_MODE"
 #define STATS_MODE_READ                     "STATS_MODE_READ"


### PR DESCRIPTION
Why I did it
Added a new field in `FLEX_COUNTER_TABLE` to represent the bulk chunk size and bulk chunk size per counter ID for bulk counter polling.
