### PR TITLE
Add tx error macros

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -95,6 +95,8 @@ namespace swss {
 #define APP_SFLOW_SESSION_TABLE_NAME      "SFLOW_SESSION_TABLE"
 #define APP_SFLOW_SAMPLE_RATE_TABLE_NAME  "SFLOW_SAMPLE_RATE_TABLE"
 
+#define APP_TX_ERR_TABLE_NAME           "TX_ERR_APPL"
+
 #define APP_NAT_TABLE_NAME              "NAT_TABLE"
 #define APP_NAPT_TABLE_NAME             "NAPT_TABLE"
 #define APP_NAT_TWICE_TABLE_NAME        "NAT_TWICE_TABLE"
@@ -463,6 +465,8 @@ namespace swss {
 #define CFG_FLOW_COUNTER_ROUTE_PATTERN_TABLE_NAME   "FLOW_COUNTER_ROUTE_PATTERN"
 #define CFG_LOGGER_TABLE_NAME                       "LOGGER"
 
+#define CFG_PORT_TX_ERR_TABLE_NAME                  "TX_ERR_CFG"
+
 #define CFG_SAG_TABLE_NAME                          "SAG"
 
 #define CFG_SUPPRESS_ASIC_SDK_HEALTH_EVENT_NAME     "SUPPRESS_ASIC_SDK_HEALTH_EVENT"
@@ -569,6 +573,8 @@ namespace swss {
 /***** Counter capability tables for Queue and Port ****/
 #define STATE_QUEUE_COUNTER_CAPABILITIES_NAME   "QUEUE_COUNTER_CAPABILITIES"
 #define STATE_PORT_COUNTER_CAPABILITIES_NAME    "PORT_COUNTER_CAPABILITIES"
+
+#define STATE_TX_ERR_TABLE_NAME                 "TX_ERR_STATE"
 
 /***** PROFILE DATABASE *****/
 


### PR DESCRIPTION
- What I did
Added TX_DROP_CFG table name macro for CONFIG_DB
Added TX_DROP_APPL table name macro for APPL_DB
Added TX_DROP_STATE table name macro for STATE_DB

-Details if related
No need to merge to sonic-net/sonic-swss-common : master, only for studying purposes