### PR TITLE
use "\n" instead of semicolon to separate redis commands in a c++ string

### DIFF
--- a/common/redispipeline.h
+++ b/common/redispipeline.h
@@ -164,7 +164,7 @@ public:
             return;
 
         m_channels.insert(channel);
-        m_luaPub += "redis.call('PUBLISH', '" + channel + "', 'G');";
+        m_luaPub += "redis.call('PUBLISH', '" + channel + "', 'G')\n";
         m_shaPub = loadRedisScript(m_luaPub);
     }
 


### PR DESCRIPTION
replace ";" with "\n" when concatenating multiple redis cmds