### PR TITLE
Improve memory usage by move ZMQ serialize buffer from ZmqProducerStateTable to ZmqClient

### DIFF
--- a/common/c-api/zmqclient.cpp
+++ b/common/c-api/zmqclient.cpp
@@ -27,9 +27,7 @@ void SWSSZmqClient_sendMsg(SWSSZmqClient zmqc, const char *dbName, const char *t
                            SWSSKeyOpFieldValuesArray arr) {
     SWSSTry({
         vector<KeyOpFieldsValuesTuple> kcos = takeKeyOpFieldValuesArray(arr);
-        size_t bufSize = BinarySerializer::serializedSize(dbName, tableName, kcos);
-        vector<char> v(bufSize);
         ((ZmqClient *)zmqc)
-            ->sendMsg(string(dbName), string(tableName), kcos, v);
+            ->sendMsg(string(dbName), string(tableName), kcos);
     });
 }

--- a/common/zmqclient.h
+++ b/common/zmqclient.h
@@ -22,8 +22,7 @@ public:
 
     void sendMsg(const std::string& dbName,
                  const std::string& tableName,
-                 const std::vector<KeyOpFieldsValuesTuple>& kcos,
-                 std::vector<char>& sendbuffer);
+                 const std::vector<KeyOpFieldsValuesTuple>& kcos);
 private:
     void initialize(const std::string& endpoint, const std::string& vrf);
 
@@ -38,6 +37,8 @@ private:
     bool m_connected;
 
     std::mutex m_socketMutex;
+    
+    std::vector<char> m_sendbuffer;
 };
 
 }

--- a/common/zmqproducerstatetable.cpp
+++ b/common/zmqproducerstatetable.cpp
@@ -62,8 +62,7 @@ void ZmqProducerStateTable::set(
     m_zmqClient.sendMsg(
                         m_dbName,
                         m_tableNameStr,
-                        kcos,
-                        m_sendbuffer);
+                        kcos);
 
     if (m_asyncDBUpdater != nullptr)
     {
@@ -91,8 +90,7 @@ void ZmqProducerStateTable::del(
     m_zmqClient.sendMsg(
                         m_dbName,
                         m_tableNameStr,
-                        kcos,
-                        m_sendbuffer);
+                        kcos);
 
     if (m_asyncDBUpdater != nullptr)
     {
@@ -110,8 +108,7 @@ void ZmqProducerStateTable::set(const std::vector<KeyOpFieldsValuesTuple> &value
     m_zmqClient.sendMsg(
                         m_dbName,
                         m_tableNameStr,
-                        values,
-                        m_sendbuffer);
+                        values);
     
     if (m_asyncDBUpdater != nullptr)
     {
@@ -134,8 +131,7 @@ void ZmqProducerStateTable::del(const std::vector<std::string> &keys)
     m_zmqClient.sendMsg(
                         m_dbName,
                         m_tableNameStr,
-                        kcos,
-                        m_sendbuffer);
+                        kcos);
     
     if (m_asyncDBUpdater != nullptr)
     {
@@ -155,8 +151,7 @@ void ZmqProducerStateTable::send(const std::vector<KeyOpFieldsValuesTuple> &kcos
     m_zmqClient.sendMsg(
                         m_dbName,
                         m_tableNameStr,
-                        kcos,
-                        m_sendbuffer);
+                        kcos);
     
     if (m_asyncDBUpdater != nullptr)
     {

--- a/common/zmqproducerstatetable.cpp
+++ b/common/zmqproducerstatetable.cpp
@@ -38,8 +38,6 @@ ZmqProducerStateTable::ZmqProducerStateTable(RedisPipeline *pipeline, const stri
 
 void ZmqProducerStateTable::initialize(DBConnector *db, const std::string &tableName, bool dbPersistence)
 {
-    m_sendbuffer.resize(MQ_RESPONSE_MAX_COUNT);
-    
     if (dbPersistence)
     {
         SWSS_LOG_DEBUG("Database persistence enabled, tableName: %s", tableName.c_str());

--- a/common/zmqproducerstatetable.h
+++ b/common/zmqproducerstatetable.h
@@ -42,8 +42,6 @@ private:
     void initialize(DBConnector *db, const std::string &tableName, bool dbPersistence);
 
     ZmqClient& m_zmqClient;
-    
-    std::vector<char> m_sendbuffer;
 
     const std::string m_dbName;
     const std::string m_tableNameStr;


### PR DESCRIPTION
#### Why I did it
Every ZmqProducerStateTable  will allocate 16MB buffer, this can be improve by share same buffer in ZmqClient.

#### How I did it
Improve memory usage by move ZMQ serialize buffer from ZmqProducerStateTable to ZmqClient.

##### Work item tracking

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Improve memory usage by move ZMQ serialize buffer from ZmqProducerStateTable to ZmqClient.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

