### PR TITLE
[ci] Use ms snapshot in buster env.

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -59,6 +59,7 @@ jobs:
     displayName: Set up sonic-sairedis branch
   - script: |
       set -ex
+      pre_run_buildinfo
       sudo apt-get update
       sudo apt-get install -qq -y \
         qtbase5-dev \

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -59,6 +59,7 @@ jobs:
     displayName: Set up sonic-swss branch
   - script: |
       set -ex
+      pre_run_buildinfo
       sudo apt-get update
       sudo apt-get install -y libhiredis0.14 libhiredis-dev
       sudo apt-get install -y libzmq5 libzmq3-dev

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -60,6 +60,8 @@ jobs:
     clean: true
   - script: |
       set -ex
+
+      pre_run_buildinfo
       sudo apt-get update
       sudo apt-get install -qq -y \
         libhiredis-dev \


### PR DESCRIPTION
debian mirror buster-backports are deprecated. Use ms snapshot instead.
https://backports.debian.org/news/Removal_of_buster-backports_from_the_debian_archive