### PR TITLE
Update start.sh for new sonic-swss soft bfd tests

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/start.sh
+++ b/.azure-pipelines/docker-sonic-vs/start.sh
@@ -75,6 +75,14 @@ elif [ "$HWSKU" == "DPU-2P" ]; then
     cp /usr/share/sonic/hwsku/sai_dpu_2p.profile /usr/share/sonic/hwsku/sai.profile
 fi
 
+if [ "$BFDOFFLOAD" == "false" ]; then
+    if ! grep -q "SAI_VS_BFD_OFFLOAD_SUPPORTED=" /usr/share/sonic/hwsku/sai.profile; then
+        echo 'SAI_VS_BFD_OFFLOAD_SUPPORTED=false' >> /usr/share/sonic/hwsku/sai.profile
+    else
+        sed -i "s/SAI_VS_BFD_OFFLOAD_SUPPORTED.*/SAI_VS_BFD_OFFLOAD_SUPPORTED=false/g" /usr/share/sonic/hwsku/sai.profile
+    fi
+fi
+
 mkdir -p /etc/swss/config.d/
 
 rm -f /var/run/rsyslogd.pid


### PR DESCRIPTION
Update start.sh for new sonic-swss soft bfd tests.
We have updated the agent pool of vstest to latest Ubuntu 20.04, but vstest is failing in bfd tests. Checked sonic-swss and sonic-sairedis repo and found there is a recent change, we need to update start.sh for new sonic-swss soft bfd tests
Original PR: https://github.com/sonic-net/sonic-swss/pull/3525 and https://github.com/sonic-net/sonic-sairedis/pull/1558