### PR TITLE
SWSSDBConnector_new_keyed to c-api

### DIFF
--- a/common/c-api/dbconnector.cpp
+++ b/common/c-api/dbconnector.cpp
@@ -30,6 +30,16 @@ SWSSResult SWSSDBConnector_new_named(const char *dbName, uint32_t timeout_ms, ui
     SWSSTry(*outDb = (SWSSDBConnector) new DBConnector(string(dbName), timeout_ms, isTcpConn));
 }
 
+SWSSResult SWSSDBConnector_new_keyed(const char *dbName, uint32_t timeout_ms, uint8_t isTcpConn,
+                                     const char *containerName, const char *netns, SWSSDBConnector *outDb) {
+    SWSSTry({
+        SonicDBKey key;
+        key.containerName = string(containerName);
+        key.netns = string(netns);
+        *outDb = (SWSSDBConnector) new DBConnector(string(dbName), timeout_ms, isTcpConn, key);
+    });
+}
+
 SWSSResult SWSSDBConnector_free(SWSSDBConnector db) {
     SWSSTry(delete (DBConnector *)db);
 }

--- a/common/c-api/dbconnector.h
+++ b/common/c-api/dbconnector.h
@@ -26,6 +26,10 @@ SWSSResult SWSSDBConnector_new_unix(int32_t dbId, const char *sock_path, uint32_
 // Pass 0 to timeout for infinity
 SWSSResult SWSSDBConnector_new_named(const char *dbName, uint32_t timeout_ms, uint8_t isTcpConn, SWSSDBConnector *outDb);
 
+// Pass 0 to timeout for infinity
+SWSSResult SWSSDBConnector_new_keyed(const char *dbName, uint32_t timeout_ms, uint8_t isTcpConn,
+                                     const char *containerName, const char *netns, SWSSDBConnector *outDb);
+
 SWSSResult SWSSDBConnector_free(SWSSDBConnector db);
 
 // Outputs 0 when key doesn't exist, 1 when key was deleted

--- a/tests/c_api_ut.cpp
+++ b/tests/c_api_ut.cpp
@@ -126,6 +126,14 @@ TEST(c_api, DBConnector) {
     EXPECT_STREQ(SWSSStrRef_c_str((SWSSStrRef)val), "myval");
     SWSSString_free(val);
 
+    // test new_keyed - empty containerName and netns should be identical to new_named
+    SWSSDBConnector db2;
+    SWSSDBConnector_new_keyed("TEST_DB", 1000, true, "", "", &db2);
+    SWSSDBConnector_get(db, "mykey", &val);
+    EXPECT_STREQ(SWSSStrRef_c_str((SWSSStrRef)val), "myval");
+    SWSSString_free(val);
+    SWSSDBConnector_free(db2);
+
     SWSSDBConnector_exists(db, "mykey", &exists);
     EXPECT_TRUE(exists);
 


### PR DESCRIPTION
The rust code using swss-common needs to access redis instances from different containers and namespaces. 