### PR TITLE
Adding new states in WarmState Adapter.

### DIFF
--- a/common/warm_restart.cpp
+++ b/common/warm_restart.cpp
@@ -13,7 +13,11 @@ const WarmStart::WarmStartStateNameMap WarmStart::warmStartStateNameMap =
     {REPLAYED,      "replayed"},
     {RECONCILED,    "reconciled"},
     {WSDISABLED,    "disabled"},
-    {WSUNKNOWN,     "unknown"}
+    {WSUNKNOWN,     "unknown"},
+    {FROZEN,        "frozen"},
+    {QUIESCENT,     "quiescent"},
+    {CHECKPOINTED,  "checkpointed"},
+    {FAILED,        "failed"}
 };
 
 const WarmStart::DataCheckStateNameMap WarmStart::dataCheckStateNameMap =

--- a/common/warm_restart.h
+++ b/common/warm_restart.h
@@ -21,6 +21,10 @@ public:
         RECONCILED,
         WSDISABLED,
         WSUNKNOWN,
+        FROZEN,
+        QUIESCENT,
+        CHECKPOINTED,
+        FAILED,
     };
 
     enum DataCheckState


### PR DESCRIPTION
Summary:
Add additional warm reboot states.
New states: FROZEN, QUIESCENT, CHECKPOINTED & FAILED.

Build Results:
divya@6faa6de402dd:/sonic/src/sonic-p4rt/sonic-swss-common$ bazel build $BAZEL_BUILD_OPTS ...
2024/08/27 19:05:30 Downloading https://releases.bazel.build/4.0.0/release/bazel-4.0.0-linux-x86_64...
Downloading: 46 MB out of 46 MB (100%)
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Analyzed 4 targets (30 packages loaded, 544 targets configured).
INFO: Found 4 targets...
INFO: Elapsed time: 121.915s, Critical Path: 6.25s
INFO: 196 processes: 98 internal, 98 linux-sandbox.
INFO: Build completed successfully, 196 total actions

Test Results:
divya@6faa6de402dd:/sonic/src/sonic-p4rt/sonic-swss-common$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Build option --cache_test_results has changed, discarding analysis cache.
INFO: Analyzed 4 targets (0 packages loaded, 544 targets configured).
INFO: Found 2 targets and 2 test targets...
INFO: Elapsed time: 0.632s, Critical Path: 0.19s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
//tests:saiaclschema_ut PASSED in 0.1s
//tests:status_code_util_test PASSED in 0.1s

Executed 2 out of 2 tests: 2 tests pass.
INFO: Build completed successfully, 3 total actions