### PR TITLE
Add a new API connect_host to SonicV2Connector

### DIFF
--- a/common/sonicv2connector.cpp
+++ b/common/sonicv2connector.cpp
@@ -29,6 +29,13 @@ void SonicV2Connector_Native::connect(const std::string& db_name, bool retry_on)
     m_dbintf.connect(db_id, db_name, retry_on);
 }
 
+void SonicV2Connector_Native::connect_host(const std::string& db_name, const std::string& host, bool retry_on)
+{
+    m_dbintf.set_redis_kwargs("", host, get_db_port(db_name));
+    int db_id = get_dbid(db_name);
+    m_dbintf.connect(db_id, db_name, retry_on);
+}
+
 void SonicV2Connector_Native::close(const std::string& db_name)
 {
     m_dbintf.close(db_name);

--- a/common/sonicv2connector.h
+++ b/common/sonicv2connector.h
@@ -18,6 +18,8 @@ public:
 
     void connect(const std::string& db_name, bool retry_on = true);
 
+    void connect_host(const std::string& db_name, const std::string& host, bool retry_on = true);
+
     void close(const std::string& db_name);
 
     void close();


### PR DESCRIPTION
This feature has been tracked in https://github.com/sonic-net/SONiC/issues/1543

### What did I do?

A new API is being added to sonicv2connector.cpp which can take the db name and host IP as an argument and connect us to the redis instance. The existing [API](https://github.com/sonic-net/sonic-swss-common/blob/202411/common/sonicv2connector.cpp#L18-L30) needs the db_name and the host_ip and port (or unix_socket) is decoded using [database_config.json](https://github.com/sonic-net/sonic-buildimage/blob/master/dockers/docker-database/database_config.json.j2). This API is tailored for use cases when you want to connect to the namespace redis instances from the same device. Our use case of aggregating VOQ counters across NPUs involves connecting to a redis instances over midplane IP hence the new API is needed.

### How did I test it?
A unit test will be added to sonic-utilities and put this to use. Also verified on Arista chassis (DCS-7804-CH) which had 7800R3A-36D2-LC linecards.