### PR TITLE
Implement component state helper API and system state helper API.

### DIFF
--- a/common/component_state_helper.cpp
+++ b/common/component_state_helper.cpp
@@ -1,0 +1,303 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "component_state_helper.h"
+
+#include <ctime>
+#include <deque>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "logger.h"
+#include "redisapi.h"
+#include "rediscommand.h"
+#include "redisreply.h"
+#include "select.h"
+#include "subscriberstatetable.h"
+
+namespace swss {
+namespace {
+
+constexpr char kComponentStateTable[] = "COMPONENT_STATE_TABLE";
+
+// Parses DB info into ComponentStateInfo.
+// Returns true if success.
+bool ParseComponentStateInfo(const std::vector<FieldValueTuple>& info,
+                             ComponentStateInfo& state_info, bool& essential) {
+  constexpr char kStateKey[] = "state";
+  constexpr char kReasonKey[] = "reason";
+  constexpr char kTimestampSecondKey[] = "timestamp-seconds";
+  constexpr char kTimestampNanoSecondKey[] = "timestamp-nanoseconds";
+  constexpr char kEssentialKey[] = "essential";
+
+  state_info = ComponentStateInfo();
+  essential = false;
+  for (const FieldValueTuple& field : info) {
+    if (fvField(field) == kStateKey) {
+      if (!StringToComponentState(fvValue(field), state_info.state)) {
+        SWSS_LOG_ERROR("Invalid state in state info: %s",
+                       fvValue(field).c_str());
+        return false;
+      }
+    } else if (fvField(field) == kReasonKey) {
+      state_info.reason = fvValue(field);
+    } else if (fvField(field) == kTimestampSecondKey) {
+      state_info.timestamp.tv_sec =
+          static_cast<time_t>(std::stoi(fvValue(field)));
+    } else if (fvField(field) == kTimestampNanoSecondKey) {
+      state_info.timestamp.tv_nsec = std::stoi(fvValue(field));
+    } else if (fvField(field) == kEssentialKey && fvValue(field) == "true") {
+      essential = true;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace
+
+std::unordered_map<SystemComponent, ComponentStateHelperInterface*,
+                   SystemComponentHash>
+    StateHelperManager::component_state_helper_instances_ =
+        std::unordered_map<SystemComponent, ComponentStateHelperInterface*,
+                           SystemComponentHash>{};
+
+std::mutex StateHelperManager::component_state_helper_instances_mutex_;
+
+SystemStateHelperInterface* StateHelperManager::system_state_helper_instance_ =
+    nullptr;
+
+std::mutex StateHelperManager::system_state_helper_instance_mutex_;
+
+ComponentStateHelper::ComponentStateHelper(SystemComponent component)
+    : component_(component),
+      component_id_(SystemComponentToString(component)),
+      db_("STATE_DB", 0) {
+  lua_sha_ = loadRedisScript(&db_, loadLuaScript("component_state_helper.lua"));
+}
+
+bool ComponentStateHelper::CallLuaScript(ComponentState state,
+                                         const std::string& reason,
+                                         bool hw_err) {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  timespec ts;
+  timespec_get(&ts, TIME_UTC);
+  char timestamp[32];  // Timestamp string has format "yyyy-MM-dd HH:mm:ss".
+  strftime(timestamp, sizeof(timestamp), "%F %T", std::localtime(&ts.tv_sec));
+  uint64_t timestamp_seconds = ts.tv_sec;
+  uint64_t timestamp_nanoseconds = ts.tv_nsec;
+  std::string hardware_err = (hw_err) ? "true" : "false";
+  std::string essential_flag =
+      (EssentialComponents().count(component_) != 0) ? "true" : "false";
+  RedisCommand command;
+  // The LUA script defines all state update logic.
+  // Refer to component_state_helper.lua for details.
+  command.format("EVALSHA %s 1 %s| %s %s %s %s %llu %llu %s %s",
+                 lua_sha_.c_str(), kComponentStateTable, component_id_.c_str(),
+                 ComponentStateToString(state).c_str(), reason.c_str(),
+                 timestamp, timestamp_seconds, timestamp_nanoseconds,
+                 hardware_err.c_str(), essential_flag.c_str());
+  RedisReply r(&db_, command, REDIS_REPLY_ARRAY);
+  auto ctx = r.getContext();
+
+  // The LUA script should return 3 arguments.
+  // Refer to component_state_helper.lua for details.
+  if (ctx->type != REDIS_REPLY_ARRAY || ctx->elements != 3) {
+    SWSS_LOG_ERROR("Error in reporting state %s: %s",
+                   ComponentStateToString(state).c_str(), reason.c_str());
+    return false;
+  }
+
+  const char* updated = ctx->element[0]->str;
+  const char* old_state = ctx->element[1]->str;
+  const char* current_state = ctx->element[2]->str;
+  if (strcmp(updated, "true") != 0) {
+    SWSS_LOG_ERROR(
+        "Component %s failed to update state from %s to %s with reason: %s.",
+        component_id_.c_str(), old_state, ComponentStateToString(state).c_str(),
+        reason.c_str());
+    return false;
+  }
+  if (state != ComponentState::kInitializing && state != ComponentState::kUp) {
+    SWSS_LOG_ERROR(
+        "Component %s successfully updated state from %s to %s with reason: "
+        "%s.",
+        component_id_.c_str(), old_state, current_state, reason.c_str());
+  }
+  state_info_.state = state;
+  state_info_.reason = reason;
+  state_info_.timestamp = ts;
+  return true;
+}
+
+bool ComponentStateHelper::ReportComponentState(ComponentState state,
+                                                const std::string& reason) {
+  return CallLuaScript(state, reason, false);
+}
+
+bool ComponentStateHelper::ReportHardwareError(const std::string& reason,
+                                               ComponentState state) {
+  if (state != ComponentState::kMinor && state != ComponentState::kError) {
+    return false;
+  }
+  return CallLuaScript(state, reason, true);
+}
+
+ComponentStateInfo ComponentStateHelper::StateInfo() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return state_info_;
+}
+
+SystemStateHelper::SystemStateHelper()
+    : db_("STATE_DB", 0),
+      select_db_("STATE_DB", 0),
+      component_state_table_(&select_db_, kComponentStateTable) {
+  for (const SystemComponent essential_component : EssentialComponents()) {
+    component_state_info_[essential_component] = ComponentStateInfo();
+  }
+  ProcessComponentStateUpdate();
+  update_thread_ = std::unique_ptr<std::thread>(
+      new std::thread(&SystemStateHelper::ComponentStateUpdateThread, this));
+}
+
+SystemStateHelper::~SystemStateHelper() {
+  if (update_thread_ != nullptr) {
+    shutdown_notification_.notify();
+    update_thread_->join();
+  }
+}
+
+void SystemStateHelper::ComponentStateUpdateThread() {
+  Select s;
+  s.addSelectable(&component_state_table_);
+  s.addSelectable(&shutdown_notification_);
+  while (true) {
+    Selectable* sel;
+    if (s.select(&sel) != Select::OBJECT) {
+      SWSS_LOG_ERROR(
+          "SystemStateHelper::ComponentStateUpdateThread failed to select "
+          "event: %s",
+          strerror(errno));
+      continue;
+    }
+    if (sel == static_cast<Selectable*>(&component_state_table_)) {
+      ProcessComponentStateUpdate();
+    } else if (sel == static_cast<Selectable*>(&shutdown_notification_)) {
+      return;
+    } else {
+      SWSS_LOG_ERROR(
+          "SystemStateHelper::ComponentStateUpdateThread unknown selectable "
+          "returned.");
+    }
+  }
+}
+
+void SystemStateHelper::ProcessComponentStateUpdate() {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  std::deque<KeyOpFieldsValuesTuple> db_updates;
+  component_state_table_.pops(db_updates);
+  for (const auto& db_update : db_updates) {
+    const std::string& component_id = kfvKey(db_update);
+    const std::string& op = kfvOp(db_update);
+    const std::vector<FieldValueTuple>& fields_values =
+        kfvFieldsValues(db_update);
+    SystemComponent component;
+    ComponentStateInfo state_info;
+    bool essential;
+    if (!ParseComponentStateInfo(fields_values, state_info, essential)) {
+      continue;  // Error is logged inside ParseComponentStateInfo.
+    }
+    if (essential && state_info.state == ComponentState::kInactive) {
+      essential_inactive_components_.insert(component_id);
+    }
+    if (!StringToSystemComponent(component_id, component)) {
+      continue;
+    }
+    if (op == DEL_COMMAND) {
+      // If state information is not present in the DB, we will use the
+      // default value of ComponentStateInfo for essential components. Refer to
+      // the comments of AllComponentStates() in
+      // component_state_helper_interface.h.
+      if (EssentialComponents().count(component) != 0) {
+        component_state_info_[component] = ComponentStateInfo();
+      } else {
+        component_state_info_.erase(component);
+      }
+      continue;
+    }
+    component_state_info_[component] = state_info;
+  }
+  if (!essential_inactive_components_.empty()) {
+    system_state_ = SystemState::kCritical;
+    system_critical_reason_ = "";
+    for (const auto& component : essential_inactive_components_) {
+      if (!system_critical_reason_.empty()) {
+        system_critical_reason_ += ", ";
+      }
+      system_critical_reason_ += component;
+    }
+    system_critical_reason_ =
+        std::string("Container monitor reports INACTIVE for components: ") +
+        system_critical_reason_;
+    return;
+  }
+  system_state_ = SystemState::kSysUp;
+  std::stringstream reason_stream;
+  for (const SystemComponent essential_component : EssentialComponents()) {
+    const ComponentStateInfo& state_info =
+        component_state_info_[essential_component];
+    if (state_info.state == ComponentState::kError ||
+        state_info.state == ComponentState::kInactive) {
+      system_state_ = SystemState::kCritical;
+      reason_stream << SystemComponentToString(essential_component)
+                    << " in state " << ComponentStateToString(state_info.state)
+                    << " with reason: " << state_info.reason << ". ";
+    } else if (state_info.state == ComponentState::kInitializing &&
+               system_state_ != SystemState::kCritical) {
+      system_state_ = SystemState::kSysInitializing;
+    }
+  }
+  system_critical_reason_ = reason_stream.str();
+  // Removing the last space in system critical reason.
+  if (!system_critical_reason_.empty()) {
+    system_critical_reason_.pop_back();
+  }
+}
+
+SystemState SystemStateHelper::GetSystemState() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return system_state_;
+}
+
+bool SystemStateHelper::IsSystemCritical() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return system_state_ == SystemState::kCritical;
+}
+
+std::string SystemStateHelper::GetSystemCriticalReason() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return system_critical_reason_;
+}
+
+std::unordered_map<SystemComponent, ComponentStateInfo, SystemComponentHash>
+SystemStateHelper::AllComponentStates() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return component_state_info_;
+}
+
+}  // namespace swss

--- a/common/component_state_helper.h
+++ b/common/component_state_helper.h
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef COMMON_COMPONENT_STATE_HELPER_H_
+#define COMMON_COMPONENT_STATE_HELPER_H_
+
+#include <cassert>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "component_state_helper_interface.h"
+#include "dbconnector.h"
+#include "logger.h"
+#include "selectableevent.h"
+#include "subscriberstatetable.h"
+
+namespace swss {
+
+// The ComponentStateHelper provides helper methods to report and query
+// component state. This class will write to DB and cache when component state
+// is reported. However, it does not update cache values from external DB
+// change. All queries will be returned from the cache instead of reading the DB
+// values.
+// When multiple processes associate to a single component, they should use the
+// SystemStateHelper to receive the correct component state.
+class ComponentStateHelper : public ComponentStateHelperInterface {
+ public:
+  ~ComponentStateHelper() = default;
+  // ComponentStateHelper is neither copyable nor movable.
+  ComponentStateHelper(const ComponentStateHelper&) = delete;
+  ComponentStateHelper& operator=(const ComponentStateHelper&) = delete;
+  ComponentStateHelper(ComponentStateHelper&&) = delete;
+  ComponentStateHelper& operator=(ComponentStateHelper&&) = delete;
+
+  // Override methods.
+  bool ReportComponentState(ComponentState state,
+                            const std::string& reason) override;
+  ComponentStateInfo StateInfo() const override;
+  bool ReportHardwareError(
+      const std::string& reason,
+      ComponentState state = ComponentState::kMinor) override;
+
+ private:
+  ComponentStateHelper(SystemComponent component);
+
+  // Execute the LUA script to update the state.
+  // Returns true if state update is successful.
+  bool CallLuaScript(ComponentState state, const std::string& reason,
+                     bool hw_err);
+
+  // The component that this helper manages.
+  SystemComponent component_;
+  // The name of this component, will be written into COMPONENT_STATE_TABLE.
+  std::string component_id_;
+  // Current state info of this component.
+  ComponentStateInfo state_info_;
+  // Hash of the component_state_helper.lua script.
+  std::string lua_sha_;
+  // Redis DB connector.
+  DBConnector db_;
+  // Mutex that guards all component state update related fields.
+  mutable std::mutex mutex_;
+
+  // The instance manager class and the unit test class need to be a friend
+  // class in order to use the private constructor.
+  friend class StateHelperManager;
+  friend class ComponentStateHelperTest;
+};
+
+class SystemStateHelper : public SystemStateHelperInterface {
+ public:
+  ~SystemStateHelper();
+  // SystemStateHelper is neither copyable nor movable.
+  SystemStateHelper(const SystemStateHelper&) = delete;
+  SystemStateHelper& operator=(const SystemStateHelper&) = delete;
+  SystemStateHelper(SystemStateHelper&&) = delete;
+  SystemStateHelper& operator=(SystemStateHelper&&) = delete;
+
+  // Override methods.
+  SystemState GetSystemState() const override;
+  bool IsSystemCritical() const override;
+  std::string GetSystemCriticalReason() const override;
+  std::unordered_map<SystemComponent, ComponentStateInfo, SystemComponentHash> AllComponentStates()
+      const override;
+
+ private:
+  SystemStateHelper();
+
+  // This function runs in a seperated thread for receiving and processing
+  // component state update notifications.
+  void ComponentStateUpdateThread();
+
+  // Processes component state update. This will update self state and
+  // dependent component states in the cache from the DB.
+  void ProcessComponentStateUpdate();
+
+  // System state.
+  SystemState system_state_;
+  // System critical reason.
+  std::string system_critical_reason_;
+  // The cached components that the container monitor reports INACTIVE state.
+  std::unordered_set<std::string> essential_inactive_components_;
+  // Component state information.
+  std::unordered_map<SystemComponent, ComponentStateInfo, SystemComponentHash> component_state_info_;
+  // Redis DB connector.
+  DBConnector db_;
+  // Redis DB connector used in the ComponentStateUpdateThread for receiving
+  // notification.
+  DBConnector select_db_;
+  // SubscriberStateTable used in the ComponentStateUpdateThread for receiving
+  // DB update.
+  SubscriberStateTable component_state_table_;
+  // Mutex that guards all component state update related fields.
+  mutable std::mutex mutex_;
+  // Thread that runs ComponentStateUpdateThread.
+  std::unique_ptr<std::thread> update_thread_;
+  // Notification used for shutting down the ComponentStateUpdateThread.
+  SelectableEvent shutdown_notification_;
+
+  // The instance manager class and the unit test class need to be a friend
+  // class in order to use the private constructor.
+  friend class StateHelperManager;
+  friend class ComponentStateHelperTest;
+};
+
+// StateHelperManager manages the singleton instances for
+// ComponentStateHelper and SystemStateHelper.
+// API user must use this manager class to access the helpers.
+class StateHelperManager {
+ public:
+  // Returns a singleton instance of ComponentStateHelperInterface for a
+  // component.
+  // If SetTestComponentSingleton is not called, this will return a
+  // ComponentStateHelper instance.
+  static ComponentStateHelperInterface& ComponentSingleton(
+      SystemComponent component) {
+    const std::lock_guard<std::mutex> lock(
+        component_state_helper_instances_mutex_);
+    if (component_state_helper_instances_.count(component) == 0) {
+      component_state_helper_instances_[component] =
+          dynamic_cast<ComponentStateHelperInterface*>(new ComponentStateHelper(component));
+    }
+    return *component_state_helper_instances_[component];
+  }
+
+  // Sets the ComponentStateHelperInterface singleton to a test instance for a
+  // component.
+  // Use for testing purpose only.
+  // This function does not delete the existing instance if it exists.
+  // Must be called before the first call of ComponentSingleton for
+  // that component.
+  static void SetTestComponentSingleton(
+      SystemComponent component, ComponentStateHelperInterface* instance) {
+    const std::lock_guard<std::mutex> lock(
+        component_state_helper_instances_mutex_);
+    assert(((void)"Attempting to overwrite a component state helper with a "
+                  "test instance.",
+            component_state_helper_instances_.count(component) == 0));
+    component_state_helper_instances_[component] = instance;
+  }
+
+  // Returns a singleton instance of SystemStateHelperInterface.
+  // If SetTestSystemSingleton is not called, this will return a
+  // SystemStateHelper instance.
+  static SystemStateHelperInterface& SystemSingleton() {
+    const std::lock_guard<std::mutex> lock(system_state_helper_instance_mutex_);
+    if (system_state_helper_instance_ == nullptr) {
+      system_state_helper_instance_ = dynamic_cast<SystemStateHelperInterface*>(new SystemStateHelper());
+    }
+    return *system_state_helper_instance_;
+  }
+
+  // Sets the SystemStateHelperInterface singleton to a test instance.
+  // Use for testing purpose only.
+  // This function does not delete the existing instance if it exists.
+  // Must be called before the first call of SystemSingleton.
+  static void SetTestSystemSingleton(SystemStateHelperInterface* instance) {
+    const std::lock_guard<std::mutex> lock(system_state_helper_instance_mutex_);
+    assert(((void)"Attempting to overwrite a system state helper with a test "
+                  "instance.",
+            system_state_helper_instance_ == nullptr));
+    system_state_helper_instance_ = instance;
+  }
+
+ private:
+  StateHelperManager() = default;
+
+  // ComponentStateHelperInterface singleton instances.
+  static std::unordered_map<SystemComponent, ComponentStateHelperInterface*, SystemComponentHash>
+      component_state_helper_instances_;
+  // SystemStateHelperInterface singleton instance.
+  static SystemStateHelperInterface* system_state_helper_instance_;
+  // Mutex that guards the ComponentStateHelperInterface singletion instances.
+  static std::mutex component_state_helper_instances_mutex_;
+  // Mutex that guards the SystemStateHelperInterface singletion instance.
+  static std::mutex system_state_helper_instance_mutex_;
+};
+
+}  // namespace swss
+
+#endif  // COMMON_COMPONENT_STATE_HELPER_H_

--- a/common/component_state_helper.lua
+++ b/common/component_state_helper.lua
@@ -1,0 +1,90 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- This script updates the component state.
+-- This script takes the following keys and arguments:
+-- KEYS[1]: component state table + table separator. Should be 'COMPONENT_STATE_TABLE|'.
+-- ARGV[1]: component ID.
+-- ARGV[2]: state. Can be INITIALIZING, UP, MINOR, ERROR, or IDLE.
+-- ARGV[3]: reason.
+-- ARGV[4]: timestamp. A human readable timestamp in the format of "yyyy-MM-dd HH:mm:ss".
+-- ARGV[5]: timestamp-seconds. An integer that represents the tv_sec field in timespec.
+-- ARGV[6]: timestamp-nanoseconds. An integer that represents the tv_nsec field in timespec.
+-- ARGV[7]: hardware error or not. Can be "true" or "false".
+-- ARGV[8]: essential component or not. Can be "true" or "false".
+-- Returns 3 entries:
+-- The first entry is a boolean string.
+-- "false" indicates that the state did not get updated.
+-- "true" indicates that the state got updated.
+-- The second entry is the previous component state. "EMPTY" if not found.
+-- The third entry is the current component state.
+
+redis.replicate_commands()
+local statetablekey = KEYS[1]..ARGV[1]
+local newstate = ARGV[2]
+local reason = ARGV[3]
+local timestamp = ARGV[4]
+local timestampsecond = ARGV[5]
+local timestampnanosecond = ARGV[6]
+local hwerr = ARGV[7]
+local essential = ARGV[8]
+local update = false
+local oldstate = redis.call('HGET', statetablekey, 'state')
+if oldstate == false then
+   oldstate = 'EMPTY'
+end
+if oldstate == 'INITIALIZING' then
+   if newstate == 'INITIALIZING' or newstate == 'UP' or newstate == 'MINOR' or newstate == 'ERROR' or newstate == 'INACTIVE' then
+      update = true
+   end
+elseif oldstate == 'UP' then
+   if newstate == 'INITIALIZING' or newstate == 'UP' or newstate == 'MINOR' or newstate == 'ERROR' or newstate == 'INACTIVE' then
+      update = true
+   end
+elseif oldstate == 'MINOR' then
+   if newstate == 'ERROR' or newstate == 'INACTIVE' then
+      update = true
+   end
+elseif oldstate == 'ERROR' then
+   if newstate == 'INACTIVE' then
+      update = true
+   end
+elseif oldstate == 'INACTIVE' then
+   update = false
+else
+   if newstate == 'INITIALIZING' or newstate == 'UP' or newstate == 'MINOR' or newstate == 'ERROR' or newstate == 'INACTIVE' then
+      update = true
+   end
+end
+if update then
+   local fvs = {}
+   table.insert(fvs, 'state')
+   table.insert(fvs, newstate)
+   table.insert(fvs, 'reason')
+   table.insert(fvs, reason)
+   table.insert(fvs, 'timestamp')
+   table.insert(fvs, timestamp)
+   table.insert(fvs, 'timestamp-seconds')
+   table.insert(fvs, timestampsecond)
+   table.insert(fvs, 'timestamp-nanoseconds')
+   table.insert(fvs, timestampnanosecond)
+   table.insert(fvs, 'hw-err')
+   table.insert(fvs, hwerr)
+   table.insert(fvs, 'essential')
+   table.insert(fvs, essential)
+   redis.call('HMSET', statetablekey, unpack(fvs))
+   return {'true', oldstate, newstate}
+else
+   return {'false', oldstate, oldstate}
+end

--- a/common/component_state_helper_interface.h
+++ b/common/component_state_helper_interface.h
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef COMMON_COMPONENT_STATE_HELPER_INTERFACE_H_
+#define COMMON_COMPONENT_STATE_HELPER_INTERFACE_H_
+
+#include <ctime>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "logger.h"
+
+namespace swss {
+
+// A component provides a set of specific services for the system.
+// A component can be composed of multiple processes.
+enum class SystemComponent {
+  kHost,
+  kP4rt,
+  kOrchagent,
+  kSyncd,
+  kTelemetry,
+  kLinkqual,
+  kPlatformMonitor,
+  kInbandmgr,
+  kSwssCfgmgr,
+};
+
+// C++11 requires custom hash for sets and tuples.
+struct SystemComponentHash {
+  template <typename T>
+  size_t operator()(T t) const {
+    return static_cast<std::size_t>(t);
+  }
+};
+
+// Component string will have the format of <container_name>:<process_name>.
+inline std::string SystemComponentToString(SystemComponent component) {
+  switch (component) {
+    case SystemComponent::kHost:
+      return "host";
+    case SystemComponent::kP4rt:
+      return "p4rt:p4rt";
+    case SystemComponent::kOrchagent:
+      return "swss:orchagent";
+    case SystemComponent::kSyncd:
+      return "syncd:syncd";
+    case SystemComponent::kTelemetry:
+      return "telemetry:telemetry";
+    case SystemComponent::kLinkqual:
+      return "linkqual:linkqual";
+    case SystemComponent::kPlatformMonitor:
+      return "pmon";
+    case SystemComponent::kInbandmgr:
+      return "inbandmgr:inbandapp";
+    case SystemComponent::kSwssCfgmgr:
+      return "swss:cfgmgr";
+    default:
+      SWSS_LOG_ERROR("Invalid SystemComponent");
+      return "invalid:invalid";
+  }
+}
+
+// Converts a component state string into SystemComponent enum.
+// Returns true if success.
+inline bool StringToSystemComponent(std::string component_str,
+                                    SystemComponent& component) {
+  static const auto* const kStringToComponentMap =
+      new std::unordered_map<std::string, SystemComponent>({
+          {"host", SystemComponent::kHost},
+          {"p4rt:p4rt", SystemComponent::kP4rt},
+          {"swss:orchagent", SystemComponent::kOrchagent},
+          {"syncd:syncd", SystemComponent::kSyncd},
+          {"telemetry:telemetry", SystemComponent::kTelemetry},
+          {"linkqual:linkqual", SystemComponent::kLinkqual},
+          {"pmon", SystemComponent::kPlatformMonitor},
+          {"inbandmgr:inbandapp", SystemComponent::kInbandmgr},
+          {"swss:cfgmgr", SystemComponent::kSwssCfgmgr},
+      });
+
+  auto lookup = kStringToComponentMap->find(component_str);
+  if (lookup == kStringToComponentMap->end()) {
+    return false;
+  }
+  component = lookup->second;
+  return true;
+}
+
+// Returns a list of essential components, which provide core functionalities to
+// the system.
+inline const std::unordered_set<SystemComponent, SystemComponentHash>&
+    EssentialComponents() {
+  static const auto* const kEssentialComponents =
+      new std::unordered_set<SystemComponent, SystemComponentHash>(
+          {SystemComponent::kHost, SystemComponent::kP4rt,
+           SystemComponent::kOrchagent, SystemComponent::kSyncd,
+           SystemComponent::kTelemetry, SystemComponent::kPlatformMonitor,
+           SystemComponent::kInbandmgr});
+  return *kEssentialComponents;
+}
+
+enum class ComponentState {
+  // Service is running but not yet ready to serve.
+  // If no state is ever reported for a component, it is also considered as in
+  // kInitializing state.
+  kInitializing,
+  // Service is ready and fully functional.
+  kUp,
+  // Service is running but encountered a minor error. Service is not impacted.
+  kMinor,
+  // Service is running but encountered an uncorrectable error. Service may be
+  // impacted.
+  kError,
+  // Service is not running and it will not be restarted.
+  kInactive,
+};
+
+inline std::string ComponentStateToString(ComponentState state) {
+  switch (state) {
+    case ComponentState::kInitializing:
+      return "INITIALIZING";
+    case ComponentState::kUp:
+      return "UP";
+    case ComponentState::kMinor:
+      return "MINOR";
+    case ComponentState::kError:
+      return "ERROR";
+    case ComponentState::kInactive:
+      return "INACTIVE";
+    default:
+      SWSS_LOG_ERROR("Invalid ComponentState");
+      return "INVALID";
+  }
+}
+
+// Converts a component state string into ComponentState enum.
+// Returns true if success.
+inline bool StringToComponentState(std::string state_str,
+                                   ComponentState& state) {
+  static const auto* const kStringToComponentStateMap =
+      new std::unordered_map<std::string, ComponentState>({
+          {"INITIALIZING", ComponentState::kInitializing},
+          {"UP", ComponentState::kUp},
+          {"MINOR", ComponentState::kMinor},
+          {"ERROR", ComponentState::kError},
+          {"INACTIVE", ComponentState::kInactive},
+      });
+
+  auto lookup = kStringToComponentStateMap->find(state_str);
+  if (lookup == kStringToComponentStateMap->end()) {
+    SWSS_LOG_ERROR("Invalid ComponentState string %s", state_str.c_str());
+    return false;
+  }
+  state = lookup->second;
+  return true;
+}
+
+// ComponentStateInfo includes the basic information of the component state.
+// It containes the state enum, reason, and timestamp.
+struct ComponentStateInfo {
+  ComponentState state = ComponentState::kInitializing;
+  std::string reason = "";
+  timespec timestamp = {};
+
+  bool operator==(const ComponentStateInfo& x) const {
+    return state == x.state && reason == x.reason &&
+           timestamp.tv_sec == x.timestamp.tv_sec &&
+           timestamp.tv_nsec == x.timestamp.tv_nsec;
+  }
+
+  bool operator!=(const ComponentStateInfo& x) const { return !((*this) == x); }
+};
+
+// ComponentStateHelperInterface provides helper methods to report and query
+// component state.
+class ComponentStateHelperInterface {
+ public:
+  virtual ~ComponentStateHelperInterface() = default;
+
+  // Reports a component state update.
+  // Returns true if the state update was successful.
+  // Returns false if the state update did not happen.
+  // Implementation should log whether state update attempt was successful or
+  // failed, no need for client code to log this again.
+  virtual bool ReportComponentState(ComponentState state,
+                                    const std::string& reason) = 0;
+
+  // Reports kMinor or kError state with indication of a hardware related error.
+  // Same as ReportComponentState but only applies to kMinor and kError state.
+  virtual bool ReportHardwareError(
+      const std::string& reason,
+      ComponentState state = ComponentState::kMinor) = 0;
+
+  // Returns the self component state information.
+  // Returns the default value of ComponentStateInfo if the component did not
+  // report any state.
+  virtual ComponentStateInfo StateInfo() const = 0;
+};
+
+// SystemState represents the overall system's status.
+// It is determined by the states of the essential components.
+enum class SystemState {
+  // When any essential component is in kInitializing state.
+  kSysInitializing,
+  // When all essential components are in the kUp or kMinor state.
+  kSysUp,
+  // When any essential component is in kError or kInactive state.
+  kCritical
+};
+
+// SystemStateHelperInterface provides helper methods to query the overall
+// system state.
+// It also provide helper methods to query all components' state information.
+class SystemStateHelperInterface {
+ public:
+  virtual ~SystemStateHelperInterface() = default;
+
+  // Gets the overall system state.
+  virtual SystemState GetSystemState() const = 0;
+
+  // Returns true if the overall system state is kCritical.
+  virtual bool IsSystemCritical() const = 0;
+
+  // Returns a description of why the system state is kCritical.
+  // Returns empty string if the system state is not kCritical.
+  // The description should be a concatenation of each kError or kInactive
+  // essential component's description, with space as separator. Each component
+  // description should have the following format (without quotes):
+  // "<component_id> in state <state_str> with reason: <reason>."
+  virtual std::string GetSystemCriticalReason() const = 0;
+
+  // Returns state information of all components.
+  // For essential components, if they didn't report any state, the
+  // kInitializing state will be returned. For non-essential components, if they
+  // didn't report any state, no state information will be returned for them.
+  virtual std::unordered_map<SystemComponent, ComponentStateInfo,
+            SystemComponentHash>
+  AllComponentStates() const = 0;
+};
+
+}  // namespace swss
+
+#endif  // COMMON_COMPONENT_STATE_HELPER_INTERFACE_H_


### PR DESCRIPTION
Summary:
Implement component state helper API and system state helper API.

Build Results:
libtool: link: g++  -fPIC -DPIC -shared -nostdlib /usr/lib/gcc/x86_64-linux-gnu/14/../../../x86_64-linux-gnu/crti.o /usr/lib/gcc/x86_64-linux-gnu/14/crtbeginS.o  pyext/py2/.libs/pyext_py2__swsscommon_la-swsscommon_wrap.o   -Wl,-rpath -Wl,/usr/local/google/home/divyagayathris/sonic_swss_changes/sonic-buildimage/src/sonic-swss-common/common/.libs common/.libs/libswsscommon.so -lpython3.12 -lhiredis -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 -L/usr/lib/gcc/x86_64-linux-gnu/14 -L/usr/lib/gcc/x86_64-linux-gnu/14/../../../x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/14/../../../../lib -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/14/../../.. -lstdc++ -lm -lc -lgcc_s /usr/lib/gcc/x86_64-linux-gnu/14/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/14/../../../x86_64-linux-gnu/crtn.o  -g -O2 -Wl,-z -Wl,now -Wl,--no-undefined   -Wl,-soname -Wl,_swsscommon.so.0 -o pyext/py2/.libs/_swsscommon.so.0.0.0
libtool: link: (cd "pyext/py2/.libs" && rm -f "_swsscommon.so.0" && ln -s "_swsscommon.so.0.0.0" "_swsscommon.so.0")
libtool: link: (cd "pyext/py2/.libs" && rm -f "_swsscommon.so" && ln -s "_swsscommon.so.0.0.0" "_swsscommon.so")
libtool: link: ar cr pyext/py2/.libs/_swsscommon.a  pyext/py2/pyext_py2__swsscommon_la-swsscommon_wrap.o
libtool: link: ranlib pyext/py2/.libs/_swsscommon.a
libtool: link: ( cd "pyext/py2/.libs" && rm -f "_swsscommon.la" && ln -s "../_swsscommon.la" "_swsscommon.la" )
make[1]: Leaving directory '/usr/local/google/home/divyagayathris/sonic_swss_changes/sonic-buildimage/src/sonic-swss-common'
