### PR TITLE
In ZmqConsumerStateTable, lock the m_receivedOperationQueue until the

### DIFF
--- a/common/zmqconsumerstatetable.cpp
+++ b/common/zmqconsumerstatetable.cpp
@@ -41,23 +41,21 @@ ZmqConsumerStateTable::ZmqConsumerStateTable(DBConnector *db, const std::string 
 
 void ZmqConsumerStateTable::handleReceivedData(const std::vector<std::shared_ptr<KeyOpFieldsValuesTuple>> &kcos)
 {
-    for (auto kco : kcos)
+    if (m_asyncDBUpdater != nullptr)
     {
-        std::shared_ptr<KeyOpFieldsValuesTuple> clone = nullptr;
-        if (m_asyncDBUpdater != nullptr)
+        for (auto kco : kcos)
         {
+            std::shared_ptr<KeyOpFieldsValuesTuple> clone = nullptr;
             // clone before put to received queue, because received data may change by consumer.
             clone = std::make_shared<KeyOpFieldsValuesTuple>(*kco);
-        }
-
-        {
-            std::lock_guard<std::mutex> lock(m_receivedQueueMutex);
-            m_receivedOperationQueue.push(kco);
-        }
-
-        if (m_asyncDBUpdater != nullptr)
-        {
             m_asyncDBUpdater->update(clone);
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_receivedQueueMutex);
+        for (auto kco : kcos)
+        {
+            m_receivedOperationQueue.push(kco);
         }
     }
     m_selectableEvent.notify(); // will release epoll


### PR DESCRIPTION
In ZmqConsumerStateTable, lock the m_receivedOperationQueue until the whole batch request is processed.

We observed in rare cases that the consumer calls pops pre-maturely before the whole batch request is received. This change will ensure pops() always return the full batch request.
