### PR TITLE
Added zmqWait in Python SWIG.

### DIFF
--- a/common/zmqclient.cpp
+++ b/common/zmqclient.cpp
@@ -169,7 +169,7 @@ void ZmqClient::sendMsg(
             //       For example when ZMQ socket still not receive reply message from last sended package.
             //       There was state machine inside ZMQ socket, when the socket is not in ready to send state, this error will happen.
             // for more detail, please check: http://api.zeromq.org/2-1:zmq-send
-            SWSS_LOG_DEBUG("zmq send retry, endpoint: %s, error: %d", m_endpoint.c_str(), zmq_err);
+            SWSS_LOG_WARN("zmq send retry, endpoint: %s, error: %d", m_endpoint.c_str(), zmq_err);
 
             retry_delay = 0;
         }

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -76,6 +76,8 @@
 %template(FieldValuePair) std::pair<std::string, std::string>;
 %template(FieldValuePairs) std::vector<std::pair<std::string, std::string>>;
 %template(FieldValuePairsList) std::vector<std::vector<std::pair<std::string, std::string>>>;
+%template(KeyFieldValuePairs) std::pair<std::string, std::vector<std::pair<std::string, std::string>>>;
+%template(KeyFieldValuePairsList) std::vector<std::pair<std::string, std::vector<std::pair<std::string, std::string>>>>;
 %template(FieldValueMap) std::map<std::string, std::string>;
 %template(VectorString) std::vector<std::string>;
 %template(ScanResult) std::pair<int64_t, std::vector<std::string>>;
@@ -288,6 +290,22 @@ T castSelectableObj(swss::Selectable *temp)
 %extend swss::DBConnector {
     %template(hgetall) hgetall<std::map<std::string, std::string>>;
 }
+
+%inline %{
+std::vector<std::pair<std::string, std::vector<swss::FieldValueTuple>>> zmqWait(swss::ZmqProducerStateTable &p)
+{
+    std::vector<std::pair<std::string, std::vector<swss::FieldValueTuple>>>  ret;
+    std::string db_name;
+    std::string table_name;
+    std::vector<std::shared_ptr<swss::KeyOpFieldsValuesTuple>> kcos_ptr;
+    p.wait(db_name, table_name, kcos_ptr);
+    for (const auto kco : kcos_ptr)
+    {
+        ret.push_back(std::pair<std::string, std::vector<swss::FieldValueTuple>>{kfvKey(*kco), kfvFieldsValues(*kco)});
+    }
+    return ret;
+}
+%}
 
 %ignore swss::TableEntryPoppable::pops(std::deque<KeyOpFieldsValuesTuple> &, const std::string &);
 %apply std::vector<std::string>& OUTPUT {std::vector<std::string> &keys};


### PR DESCRIPTION
### Summary:
Added the inline SWIG wrapper to expose the zmqWait functionality for ZmqProducerStateTable which allows the Python to wait on the ZMQ channel and retrieve the key-field-value tuples directly.

### Build Results:
(venv) divyagayathris@divyagayathris-16:~/30May/sonic-buildimage/src/sonic-swss-common$ make
...
pyext/py2/.libs/_swsscommon.so.0.0.0
libtool: link: (cd "pyext/py2/.libs" && rm -f "_swsscommon.so.0" && ln -s "_swsscommon.so.0.0.0" "_swsscommon.so.0")
libtool: link: (cd "pyext/py2/.libs" && rm -f "_swsscommon.so" && ln -s "_swsscommon.so.0.0.0" "_swsscommon.so")
libtool: link: ar cr pyext/py2/.libs/_swsscommon.a  pyext/py2/pyext_py2__swsscommon_la-swsscommon_wrap.o
libtool: link: ranlib pyext/py2/.libs/_swsscommon.a
libtool: link: ( cd "pyext/py2/.libs" && rm -f "_swsscommon.la" && ln -s "../_swsscommon.la" "_swsscommon.la" )
make[1]: Leaving directory '/usr/local/google/home/divyagayathris/30May/sonic-buildimage/src/sonic-swss-common'
