### PR TITLE
Update the ORCH_ZMQ_PORT value to 8100 to match the current configuration in orchange.sh

### DIFF
--- a/common/zmqserver.h
+++ b/common/zmqserver.h
@@ -13,7 +13,7 @@
 #define MQ_WATERMARK 10000
 
 /***** ZMQ PORT *****/
-static const int ORCH_ZMQ_PORT = 8020;
+static const int ORCH_ZMQ_PORT = 8100;
 
 namespace swss {
 


### PR DESCRIPTION
Update the ORCH_ZMQ_PORT value to 8100 to match the current configuration in orchange.sh

#### Why I did it
Currently orchagent using ZMQ port 8100 in orchagent.sh

#### How I did it
Change ORCH_ZMQ_PORT to 8100

##### Work item tracking
- Microsoft ADO: 32582830

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Update the ORCH_ZMQ_PORT value to 8100 to match the current configuration in orchange.sh

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

