### PR TITLE
[azp] Only grab libyang v1 libs for AZP jobs

### DIFF
--- a/.azure-pipelines/build-sairedis-template.yml
+++ b/.azure-pipelines/build-sairedis-template.yml
@@ -102,8 +102,8 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang-*.deb
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex

--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -105,8 +105,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-genl*.deb
         target/debs/${{ parameters.debian_version }}/libnl-route*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf*.deb
-        target/debs/${{ parameters.debian_version }}/libyang-*.deb
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
         target/debs/${{ parameters.debian_version }}/libprotobuf*.deb
         target/debs/${{ parameters.debian_version }}/libprotoc*.deb
         target/debs/${{ parameters.debian_version }}/protobuf-compiler*.deb

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -82,8 +82,8 @@ jobs:
       ${{ else }}:
         artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libyang-*.deb
-        target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libyang-*_1.0*.deb
+        target/debs/${{ parameters.debian_version }}/libyang_1.0*.deb
     displayName: "Download libyang from ${{ parameters.arch }} common lib"
   - script: |
       set -ex


### PR DESCRIPTION
Limit grabbed libyang libraries to only v1.

Upgrading to libyang v3 (https://github.com/sonic-net/sonic-buildimage/pull/21679) is causing the swss-common pipeline build to fail. The pipeline assumes that any package starting with `libyang_` or `libyang-` is a libyang v1 package and tries to install it. However, the dev header package for libyang v3 starts with `libyang-`, so the pipeline tries to download/install it as well, which causes the build to fail since it depends on the base libyang v3 package which is not grabbed because it starts with `libyang3`.