### PR TITLE
swss-common: Improve batch key delete

### DIFF
--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1046,7 +1046,7 @@ void DBConnector::del(const std::vector<std::string>& keys)
     SWSS_LOG_ENTER();
 
     RedisPipeline pipe(this);
-    std::string joined_keys = "";
+    std::string joined_keys;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (!joined_keys.empty()) {
             joined_keys.append(" ");
@@ -1056,7 +1056,7 @@ void DBConnector::del(const std::vector<std::string>& keys)
             RedisCommand del;
             del.formatDEL(joined_keys);
             pipe.push(del, REDIS_REPLY_INTEGER);
-            joined_keys = "";
+            joined_keys.clear();
         }
     }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1041,20 +1041,31 @@ void DBConnector::hmset(const std::unordered_map<std::string, std::vector<std::p
     pipe.flush();
 }
 
-void DBConnector::del(const std::vector<std::string>& keys)
+void DBConnector::del(const std::vector<std::string>& keys, bool enable_batched_keys_delete)
 {
     SWSS_LOG_ENTER();
-
     RedisPipeline pipe(this);
-    std::vector<std::string> batched_keys;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        batched_keys.push_back(keys[i]);
-        if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
-            RedisCommand del;
-            del.formatDEL(batched_keys);
-            pipe.push(del, REDIS_REPLY_INTEGER);
-            batched_keys.clear();
+
+    if (enable_batched_keys_delete) {
+        std::vector<std::string> batched_keys;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            batched_keys.push_back(keys[i]);
+            if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
+                RedisCommand del;
+                del.formatDEL(batched_keys);
+                pipe.push(del, REDIS_REPLY_INTEGER);
+                batched_keys.clear();
+            }
         }
+    }
+    else
+    {
+        for (auto& key : keys)
+	{
+	    RedisCommand del;
+	    del.formatDEL(key);
+	    pipe.push(del, REDIS_REPLY_INTEGER);
+	}
     }
 
     pipe.flush();

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1055,8 +1055,9 @@ void DBConnector::del(const std::vector<std::string>& keys)
         if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
             RedisCommand del;
             del.formatDEL(joined_keys);
+            SWSS_LOG_ERROR("%s", del.toPrintableString());
             pipe.push(del, REDIS_REPLY_INTEGER);
-            joined_keys.clear();
+	    joined_keys.clear();
         }
     }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1046,17 +1046,14 @@ void DBConnector::del(const std::vector<std::string>& keys)
     SWSS_LOG_ENTER();
 
     RedisPipeline pipe(this);
-    std::string joined_keys;
+    std::vector<std::string> batched_keys;
     for (size_t i = 0; i < keys.size(); ++i) {
-        if (!joined_keys.empty()) {
-            joined_keys.append(" ");
-        }
-        joined_keys.append(keys[i]);
+        batched_keys.push_back(keys[i]);
         if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
             RedisCommand del;
-            del.formatDEL(joined_keys);
+            del.formatDEL(batched_keys);
             pipe.push(del, REDIS_REPLY_INTEGER);
-	    joined_keys.clear();
+            batched_keys.clear();
         }
     }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1055,7 +1055,7 @@ void DBConnector::del(const std::vector<std::string>& keys)
         if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
             RedisCommand del;
             del.formatDEL(joined_keys);
-            SWSS_LOG_ERROR("%s", del.toPrintableString().c_str());
+            SWSS_LOG_ERROR("[Thanh DGB]: %s", del.toPrintableString().c_str());
             pipe.push(del, REDIS_REPLY_INTEGER);
 	    joined_keys.clear();
         }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1055,7 +1055,7 @@ void DBConnector::del(const std::vector<std::string>& keys)
         if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
             RedisCommand del;
             del.formatDEL(joined_keys);
-            SWSS_LOG_ERROR("%s", del.toPrintableString());
+            SWSS_LOG_ERROR("%s", del.toPrintableString()).c_str();
             pipe.push(del, REDIS_REPLY_INTEGER);
 	    joined_keys.clear();
         }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1057,6 +1057,7 @@ void DBConnector::del(const std::vector<std::string>& keys)
             batched_keys.clear();
         }
     }
+
     pipe.flush();
 }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1055,7 +1055,7 @@ void DBConnector::del(const std::vector<std::string>& keys)
         if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
             RedisCommand del;
             del.formatDEL(joined_keys);
-            SWSS_LOG_ERROR("%s", del.toPrintableString()).c_str();
+            SWSS_LOG_ERROR("%s", del.toPrintableString().c_str());
             pipe.push(del, REDIS_REPLY_INTEGER);
 	    joined_keys.clear();
         }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1055,7 +1055,6 @@ void DBConnector::del(const std::vector<std::string>& keys)
         if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
             RedisCommand del;
             del.formatDEL(joined_keys);
-            SWSS_LOG_ERROR("[Thanh DGB]: %s", del.toPrintableString().c_str());
             pipe.push(del, REDIS_REPLY_INTEGER);
 	    joined_keys.clear();
         }

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -19,7 +19,7 @@ using namespace std;
 using namespace swss;
 
 namespace {
-constexpr size_t KEY_DEL_CHUNK_SIZE = 10000;
+constexpr size_t KEY_DEL_CHUNK_SIZE = 128;
 }
 
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1048,7 +1048,8 @@ void DBConnector::del(const std::vector<std::string>& keys, bool enable_batched_
 
     if (enable_batched_keys_delete) {
         std::vector<std::string> batched_keys;
-        for (size_t i = 0; i < keys.size(); ++i) {
+        for (size_t i = 0; i < keys.size(); ++i)
+        {
             batched_keys.push_back(keys[i]);
             if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
                 RedisCommand del;
@@ -1061,11 +1062,11 @@ void DBConnector::del(const std::vector<std::string>& keys, bool enable_batched_
     else
     {
         for (auto& key : keys)
-	{
-	    RedisCommand del;
-	    del.formatDEL(key);
-	    pipe.push(del, REDIS_REPLY_INTEGER);
-	}
+        {
+            RedisCommand del;
+            del.formatDEL(key);
+            pipe.push(del, REDIS_REPLY_INTEGER);
+        }
     }
 
     pipe.flush();

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1057,7 +1057,6 @@ void DBConnector::del(const std::vector<std::string>& keys)
             batched_keys.clear();
         }
     }
-
     pipe.flush();
 }
 

--- a/common/dbconnector.cpp
+++ b/common/dbconnector.cpp
@@ -1026,20 +1026,17 @@ void DBConnector::del(const std::vector<std::string>& keys)
 
     RedisPipeline pipe(this);
     std::string joined_keys = "";
-    size_t joined_keys_size = 0;
     for (size_t i = 0; i < keys.size(); ++i) {
         if (!joined_keys.empty()) {
-           joined_keys.append(" ");
-       }
-       joined_keys.append(keys[i]);
-       ++joined_keys_size;
-       if ((joined_keys_size == KEY_DEL_CHUNK_SIZE) || (i == keys.size()-1)) {
-           RedisCommand del;
-           del.formatDEL(joined_keys);
-           pipe.push(del, REDIS_REPLY_INTEGER);
-           joined_keys = "";
-           joined_keys_size = 0;
-       }
+            joined_keys.append(" ");
+        }
+        joined_keys.append(keys[i]);
+        if (((i + 1) % KEY_DEL_CHUNK_SIZE == 0) || (i == keys.size()-1)) {
+            RedisCommand del;
+            del.formatDEL(joined_keys);
+            pipe.push(del, REDIS_REPLY_INTEGER);
+            joined_keys = "";
+        }
     }
 
     pipe.flush();

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -261,7 +261,7 @@ public:
 
     int64_t hdel(const std::string &key, const std::vector<std::string> &fields);
 
-    void del(const std::vector<std::string>& keys);
+    void del(const std::vector<std::string>& keys, bool enable_batched_keys_delete = false);
 
     template <typename ReturnType=std::unordered_map<std::string, std::string>>
     ReturnType hgetall(const std::string &key);

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -261,7 +261,7 @@ public:
 
     int64_t hdel(const std::string &key, const std::vector<std::string> &fields);
 
-    void del(const std::vector<std::string>& keys, bool enable_batched_keys_delete = true);
+    void del(const std::vector<std::string>& keys);
 
     template <typename ReturnType=std::unordered_map<std::string, std::string>>
     ReturnType hgetall(const std::string &key);

--- a/common/dbconnector.h
+++ b/common/dbconnector.h
@@ -261,7 +261,7 @@ public:
 
     int64_t hdel(const std::string &key, const std::vector<std::string> &fields);
 
-    void del(const std::vector<std::string>& keys, bool enable_batched_keys_delete = false);
+    void del(const std::vector<std::string>& keys, bool enable_batched_keys_delete = true);
 
     template <typename ReturnType=std::unordered_map<std::string, std::string>>
     ReturnType hgetall(const std::string &key);

--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -127,6 +127,15 @@ void RedisCommand::formatDEL(const std::string& key)
     return format("DEL %s", key.c_str());
 }
 
+void RedisCommand::formatDEL(const std::vector<std::string>& keys)
+{
+    if (keys.empty()) throw std::invalid_argument("empty values");
+
+    std::vector<string> args = {"DEL"};
+    args.insert(args.end(), keys.begin(), keys.end());
+    format(args);
+}
+
 int RedisCommand::appendTo(redisContext *ctx) const
 {
     return redisAppendFormattedCommand(ctx, c_str(), length());

--- a/common/rediscommand.cpp
+++ b/common/rediscommand.cpp
@@ -127,6 +127,7 @@ void RedisCommand::formatDEL(const std::string& key)
     return format("DEL %s", key.c_str());
 }
 
+/* Format DEL multiple keys command */
 void RedisCommand::formatDEL(const std::vector<std::string>& keys)
 {
     if (keys.empty()) throw std::invalid_argument("empty values");

--- a/common/rediscommand.h
+++ b/common/rediscommand.h
@@ -66,6 +66,9 @@ public:
     /* Format DEL key command */
     void formatDEL(const std::string& key);
 
+    /* Format DEL multiple keys command */
+    void formatDEL(const std::vector<std::string>& keys);
+
     int appendTo(redisContext *ctx) const;
 
     std::string toPrintableString() const;

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -555,10 +555,10 @@ TEST(DBConnector, DelMultipleKeys)
             db.set(key, "value");
             keys.push_back(key);
         }
-        EXPECT_EQ(db.keys().size(), num_key);
+        EXPECT_EQ(db.keys("*").size(), num_key);
 
         db.del(keys);
-        EXPECT_EQ(db.keys().size(), 0);
+        EXPECT_EQ(db.keys("*").size(), 0);
     }
 }
 

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -535,6 +535,33 @@ TEST(DBConnector, HmsetAndDel)
     }
 }
 
+TEST(DBConnector, DelMultipleKeys)
+{
+    DBConnector db("TEST_DB", 0, true);
+    clearDB();
+
+    vector<size_t> num_keys = {1, 128, 300};
+    vector<pair<string, string>> keys;
+    for (size_t i = 0; i < num_keys.size(); ++i)
+    {
+        size_t num_key = num_keys[i];
+        if (i > 0)
+        {
+            keys.clear();
+        }
+        for (size_t j = 0; j < num_key; ++j)
+        {
+            string key = "hash_key_" + to_string(j);
+            db.set(key, "value");
+            keys.push_back(key);
+        }
+        EXPECT_EQ(db.keys().size(), num_key);
+
+        db.del(keys);
+        EXPECT_EQ(db.keys().size(), 0);
+    }
+}
+
 TEST(DBConnector, test)
 {
     thread *producerThreads[NUMBER_OF_THREADS];

--- a/tests/redis_ut.cpp
+++ b/tests/redis_ut.cpp
@@ -541,7 +541,7 @@ TEST(DBConnector, DelMultipleKeys)
     clearDB();
 
     vector<size_t> num_keys = {1, 128, 300};
-    vector<pair<string, string>> keys;
+    vector<string> keys;
     for (size_t i = 0; i < num_keys.size(); ++i)
     {
         size_t num_key = num_keys[i];


### PR DESCRIPTION
* Adding a change to delete multiple keys per one DEL operation instead of one key per DEL

Signed-off-by: Thanh sonphung@google.com