### PR TITLE
Prevent adding new CFG table since it is auto generated

### DIFF
--- a/.github/workflows/prevent-cfg.yml
+++ b/.github/workflows/prevent-cfg.yml
@@ -100,8 +100,8 @@ jobs:
           allowed_dict["$macro"]=1
         done
 
-        # Find all CFG_ macros in the current schema.h
-        current_cfg_macros=$(grep -o 'CFG_[A-Za-z_]*' common/schema.h | sort | uniq)
+        # Find all CFG_ macros in the current schema.h (only from #define statements)
+        current_cfg_macros=$(grep '#define CFG_' common/schema.h | grep -o 'CFG_[A-Za-z0-9_]*' | sort | uniq)
 
         # Check if any new CFG_ macros have been added
         new_macros=""

--- a/.github/workflows/prevent-cfg.yml
+++ b/.github/workflows/prevent-cfg.yml
@@ -114,12 +114,10 @@ jobs:
         if [ ! -z "$new_macros" ]; then
           echo "ERROR: New CFG_ macros detected in common/schema.h:"
           echo -e "$new_macros"
-          echo "CFG_ macros should NOT be added directly to schema.h."
+          echo "CFG_XXX_TABLE_NAME macros should NOT be added directly to schema.h."
           echo "Instead, CFG_ macros are auto-generated from YANG models via cfg_schema.h."
           echo "To add a new configuration table:"
-          echo "1. Add the table definition to the appropriate YANG model"
-          echo "2. The CFG_XXX_TABLE_NAME macro will be automatically generated in cfg_schema.h"
-          echo "3. The macro will be available through the #include \"cfg_schema.h\" directive"
+          echo "Add the table relative YANG model. The CFG_XXX_TABLE_NAME macro will be automatically generated."
           exit 1
         fi
 

--- a/.github/workflows/prevent-cfg.yml
+++ b/.github/workflows/prevent-cfg.yml
@@ -1,0 +1,126 @@
+name: Prevent CFG_ Macro Additions
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '202[2-9][0-9][0-9]'
+    paths:
+      - 'common/schema.h'
+  pull_request:
+    branches:
+      - 'master'
+      - '202[2-9][0-9][0-9]'
+    paths:
+      - 'common/schema.h'
+
+jobs:
+  check-cfg-macros:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Check for new CFG_ macros in schema.h
+      run: |
+        echo "Checking for new CFG_ macro additions in common/schema.h..."
+
+        # Allowed legacy CFG_ macros that should remain in schema.h
+        # DO NOT add new entries to this list
+        ALLOWED_CFG_MACROS=(
+          CFG_PORT_CABLE_LEN_TABLE_NAME
+          CFG_SEND_TO_INGRESS_PORT_TABLE_NAME
+          CFG_GEARBOX_TABLE_NAME
+          CFG_INTF_TABLE_NAME
+          CFG_LAG_INTF_TABLE_NAME
+          CFG_VLAN_INTF_TABLE_NAME
+          CFG_VLAN_SUB_INTF_TABLE_NAME
+          CFG_LAG_TABLE_NAME
+          CFG_LAG_MEMBER_TABLE_NAME
+          CFG_VLAN_STACKING_TABLE_NAME
+          CFG_VLAN_TRANSLATION_TABLE_NAME
+          CFG_FDB_TABLE_NAME
+          CFG_SWITCH_TABLE_NAME
+          CFG_NTP_GLOBAL_TABLE_NAME
+          CFG_FLEX_COUNTER_TABLE_NAME
+          CFG_WATERMARK_TABLE_NAME
+          CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME
+          CFG_TC_TO_DOT1P_MAP_TABLE_NAME
+          CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME
+          CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+          CFG_DEFAULT_LOSSLESS_BUFFER_PARAMETER
+          CFG_NEIGH_SUPPRESS_VLAN_TABLE_NAME
+          CFG_VNET_RT_TABLE_NAME
+          CFG_VNET_RT_TUNNEL_TABLE_NAME
+          CFG_PASS_THROUGH_ROUTE_TABLE_NAME
+          CFG_DEBUG_COUNTER_TABLE_NAME
+          CFG_DEBUG_COUNTER_DROP_REASON_TABLE_NAME
+          CFG_STP_GLOBAL_TABLE_NAME
+          CFG_STP_VLAN_TABLE_NAME
+          CFG_STP_VLAN_PORT_TABLE_NAME
+          CFG_STP_PORT_TABLE_NAME
+          CFG_MCLAG_TABLE_NAME
+          CFG_MCLAG_INTF_TABLE_NAME
+          CFG_VRRP_TABLE_NAME
+          CFG_VRRP6_TABLE_NAME
+          CFG_RATES_TABLE_NAME
+          CFG_FG_NHG
+          CFG_FG_NHG_PREFIX
+          CFG_FG_NHG_MEMBER
+          CFG_CHASSIS_MODULE_TABLE
+          CFG_TWAMP_SESSION_TABLE_NAME
+          CFG_LOGGING_TABLE_NAME
+          CFG_DHCP_TABLE
+          CFG_DPU_TABLE
+          CFG_DASH_HA_GLOBAL_CONFIG_TABLE_NAME
+          CFG_LOGGER_TABLE_NAME
+          CFG_SAG_TABLE_NAME
+          CFG_SUPPRESS_ASIC_SDK_HEALTH_EVENT_NAME
+          CFG_PAC_PORT_CONFIG_TABLE
+          CFG_PAC_GLOBAL_CONFIG_TABLE
+          CFG_PAC_HOSTAPD_GLOBAL_CONFIG_TABLE
+          CFG_SRV6_MY_SID_TABLE_NAME
+          CFG_SRV6_MY_LOCATOR_TABLE_NAME
+          CFG_DTEL_TABLE_NAME
+          CFG_DTEL_REPORT_SESSION_TABLE_NAME
+          CFG_DTEL_INT_SESSION_TABLE_NAME
+          CFG_DTEL_QUEUE_REPORT_TABLE_NAME
+          CFG_DTEL_EVENT_TABLE_NAME
+          CFG_FABRIC_MONITOR_DATA_TABLE_NAME
+          CFG_FABRIC_MONITOR_PORT_TABLE_NAME
+          CFG_WARM_RESTART_TABLE_NAME
+          CFG_HIGH_FREQUENCY_TELEMETRY_PROFILE_TABLE_NAME
+          CFG_HIGH_FREQUENCY_TELEMETRY_GROUP_TABLE_NAME
+        )
+
+        # Create associative array for fast lookup
+        declare -A allowed_dict
+        for macro in "${ALLOWED_CFG_MACROS[@]}"; do
+          allowed_dict["$macro"]=1
+        done
+
+        # Find all CFG_ macros in the current schema.h
+        current_cfg_macros=$(grep -o 'CFG_[A-Za-z_]*' common/schema.h | sort | uniq)
+
+        # Check if any new CFG_ macros have been added
+        new_macros=""
+        for macro in $current_cfg_macros; do
+          if [[ -z "${allowed_dict[$macro]}" ]]; then
+            new_macros="$new_macros$macro\n"
+          fi
+        done
+
+        if [ ! -z "$new_macros" ]; then
+          echo "ERROR: New CFG_ macros detected in common/schema.h:"
+          echo -e "$new_macros"
+          echo "CFG_ macros should NOT be added directly to schema.h."
+          echo "Instead, CFG_ macros are auto-generated from YANG models via cfg_schema.h."
+          echo "To add a new configuration table:"
+          echo "1. Add the table definition to the appropriate YANG model"
+          echo "2. The CFG_XXX_TABLE_NAME macro will be automatically generated in cfg_schema.h"
+          echo "3. The macro will be available through the #include \"cfg_schema.h\" directive"
+          exit 1
+        fi
+
+        echo "No new CFG_ macros detected. All CFG_ macros are from the allowed legacy list."


### PR DESCRIPTION
Add a checker to prevent adding new CFG_ macros when update common/schema.h.
#### Why I did it
CFG_XXX_TABLE_NAME macros should be auto-generated from YANG models via cfg_schema.h.
#### How I did it
Introduced .github/workflows/prevent-cfg.yml which runs on PRs that modify common/schema.h.
It extracts all CFG_ macros defined in the file and compares them against an allowed legacy list.
##### Work item tracking
- Microsoft ADO: 35075048

#### How to verify it
Manual test CFG change and other change in common/schema.h
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

