### PR TITLE
fix: use fgets return value as loop condition in exec()

### DIFF
--- a/common/exec.cpp
+++ b/common/exec.cpp
@@ -26,12 +26,9 @@ int exec(const string &cmd, string &stdout)
     }
 
     stdout.clear();
-    while (!feof(pipe))
+    while (fgets(buffer.data(), buffsz, pipe) != NULL)
     {
-        if (fgets(buffer.data(), buffsz, pipe) != NULL)
-        {
-            stdout += buffer.data();
-        }
+        stdout += buffer.data();
     }
 
     int ret;


### PR DESCRIPTION
## What

Fix incorrect loop condition in `exec()` in `common/exec.cpp`.

## Why

Using `!feof(pipe)` as a loop condition has two problems:

1. `feof()` only becomes true *after* a read has already hit EOF, so the loop always executes one extra iteration where `fgets()` returns NULL.
2. `feof()` does not detect I/O errors (`ferror`). On a read error, `fgets()` returns NULL but `feof()` remains false, causing an infinite loop.

## How

Drive the loop directly on the `fgets()` return value. This handles both EOF and I/O errors correctly with a single condition, and eliminates the redundant inner `if` guard.

```cpp
// Before
while (!feof(pipe))
{
    if (fgets(buffer.data(), buffsz, pipe) != NULL)
    {
        stdout += buffer.data();
    }
}

// After
while (fgets(buffer.data(), buffsz, pipe) != NULL)
{
    stdout += buffer.data();
}
```
