### PR TITLE
fix: mark IpPrefix::isValid() as const

### DIFF
--- a/common/ipprefix.cpp
+++ b/common/ipprefix.cpp
@@ -61,7 +61,7 @@ IpPrefix::IpPrefix(const ip_addr_t &ip, int mask) : m_ip(ip), m_mask(mask)
     }
 }
 
-bool IpPrefix::isValid()
+bool IpPrefix::isValid() const
 {
     if (m_mask < 0) return false;
     

--- a/common/ipprefix.h
+++ b/common/ipprefix.h
@@ -202,7 +202,7 @@ public:
     std::string to_string() const;
 
 private:
-    bool isValid();
+    bool isValid() const;
 
     IpAddress m_ip;
     int m_mask;


### PR DESCRIPTION
## Why

`IpPrefix::isValid()` only reads `m_ip` and `m_mask` — it does not modify any member. Without `const`, it cannot be called on `const IpPrefix` objects or `const IpPrefix&` references, making it unusable in const-correct contexts despite all other observer methods (`to_string`, `isV4`, `getIp`, etc.) already being correctly marked `const`.

## How

Add `const` to the declaration in `ipprefix.h` and the definition in `ipprefix.cpp`.

## How to verify

Existing unit tests pass. Additionally, the following now compiles correctly:
```cpp
const IpPrefix p("192.168.1.0/24");
p.isValid(); // previously would not compile
```
