### PR TITLE
perf: eliminate redundant map lookups in swssPrioNotify and swssOutputNotify

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -78,7 +78,8 @@ void Logger::swssPrioNotify(const std::string& component, const std::string& pri
 {
     auto& logger = getInstance();
 
-    if (priorityStringMap.find(prioStr) == priorityStringMap.end())
+    auto it = priorityStringMap.find(prioStr);
+    if (it == priorityStringMap.end())
     {
         SWSS_LOG_ERROR("Invalid loglevel. Setting to NOTICE. %s", prioStr.c_str());
         logger.m_minPrio = SWSS_NOTICE;
@@ -86,7 +87,7 @@ void Logger::swssPrioNotify(const std::string& component, const std::string& pri
     else
     {
         SWSS_LOG_DEBUG("Changing logger minPrio to %s", prioStr.c_str());
-        logger.m_minPrio = priorityStringMap.at(prioStr);
+        logger.m_minPrio = it->second;
     }
 }
 
@@ -100,14 +101,15 @@ void Logger::swssOutputNotify(const std::string& component, const std::string& o
 {
     auto& logger = getInstance();
 
-    if (outputStringMap.find(outputStr) == outputStringMap.end())
+    auto it = outputStringMap.find(outputStr);
+    if (it == outputStringMap.end())
     {
         SWSS_LOG_ERROR("Invalid logoutput. Setting to SYSLOG. %s", outputStr.c_str());
         logger.m_output = SWSS_SYSLOG;
     }
     else
     {
-        logger.m_output = outputStringMap.at(outputStr);
+        logger.m_output = it->second;
     }
 }
 


### PR DESCRIPTION
## Why

`swssPrioNotify` and `swssOutputNotify` each perform two map lookups on the success path:
1. `find()` to check if the key exists
2. `at()` to retrieve the value

Both are O(log n) on `std::map`, so the success path pays the cost twice unnecessarily.

## How

Store the iterator returned by `find()` and use `it->second` directly in the else branch, eliminating the second lookup.

## How to verify

Existing logger unit tests pass. Behavior is identical — only the number of map traversals changes.
