### PR TITLE
fix strncpy truncation; enable FORTIFY_SOURCE=3

### DIFF
--- a/common/events_common.h
+++ b/common/events_common.h
@@ -286,7 +286,7 @@ struct serialization
             rc = zmq_msg_init_size(&msg, s.size());
         }
         if (rc == 0) {
-            strncpy((char *)zmq_msg_data(&msg), s.c_str(), s.size());
+            memcpy((char *)zmq_msg_data(&msg), s.c_str(), s.size());
         }
         return rc;
     }

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@ include /usr/share/dpkg/default.mk
 
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
 
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS


### PR DESCRIPTION
## Why I did it

`zmq_msg_init_size()` allocates a byte buffer sized exactly `s.size()` — no room for a null terminator. The ZMQ message reader (`zmsg_to_map`) constructs a `std::string` using `zmq_msg_size()`, so null termination is irrelevant. `strncpy` is the wrong primitive here; `memcpy` is semantically correct for raw byte blobs and eliminates the FORTIFY_SOURCE=3 provable-truncation diagnostic.

Also upgrade FORTIFY_SOURCE to level 3 in `debian/rules` so all future builds use the stronger compile-time check. dpkg sets =2 by default; the `-U` flag clears it before setting =3.

## How I did it

- `common/events_common.h`: replace `strncpy` with `memcpy` in `map_to_zmsg()`
- `debian/rules`: add `DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3`

## How to verify it

Build passes cleanly with `dpkg-buildpackage`. No compiler warnings or errors related to FORTIFY_SOURCE.