### PR TITLE
[ci] replace python3-pip with uv in vs test pipeline

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -70,7 +70,7 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install pytest flaky exabgp docker
+      sudo uv pip install --system pytest flaky exabgp docker
 
       # install packages for kvm test
       sudo apt-get -o DPkg::Lock::Timeout=600 install -y libvirt-clients \
@@ -106,7 +106,7 @@ jobs:
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
       # env otherwise triggers.
       sudo apt-get install -y python3-cffi
-      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
+      sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -106,7 +106,7 @@ jobs:
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
       # env otherwise triggers. --no-build-isolation needs wheel present
       # in the environment to provide bdist_wheel, so install it first.
-      sudo apt-get install -y python3-cffi
+      sudo apt-get install -y python3-cffi python3-dev
       sudo uv pip install --system wheel
       sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -104,8 +104,10 @@ jobs:
       # from PyPI instead — same fallback as the inline amd64/ubuntu-22.04
       # job. --no-build-isolation + apt's python3-cffi sidesteps a cffi
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
-      # env otherwise triggers.
+      # env otherwise triggers. --no-build-isolation needs wheel present
+      # in the environment to provide bdist_wheel, so install it first.
       sudo apt-get install -y python3-cffi
+      sudo uv pip install --system wheel
       sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb 


### PR DESCRIPTION
S360 flags `python3-pip` on the CI agent as a security vulnerability
Remove usage of `pip3` from the vs test pipeline script following the removal of `python3-pip` from the CI agent. Replace all `pip3 install` calls with `uv pip install --system` to maintain equivalent system-wide package installation behaviour.

Test result:
202605: CI env change. with this change, 202605 branch can start to run the vs test successfully