### PR TITLE
Cap consecutive readData error logging to avoid filling /var/log

### DIFF
--- a/common/select.cpp
+++ b/common/select.cpp
@@ -2,6 +2,8 @@
 #include "common/logger.h"
 #include "common/select.h"
 #include <algorithm>
+#include <chrono>
+#include <thread>
 #include <stdio.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -175,15 +177,25 @@ int Select::select(Selectable **c, int timeout, bool interrupt_on_signal)
     /* check if we have some data */
     ret = poll_descriptors(c, 0);
 
-    /* return if we have data, we have an error or desired timeout was 0 */
-    if (ret != Select::TIMEOUT || timeout == 0)
+    /* return immediately if appropriate */
+    if (ret == Select::OBJECT || ret == Select::SIGNALINT || timeout == 0)
+    {
         return ret;
+    }
 
-    /* wait for data */
-    ret = poll_descriptors(c, timeout, interrupt_on_signal);
+    if (ret == Select::TIMEOUT)
+    {
+        ret = poll_descriptors(c, timeout, interrupt_on_signal);
+    }
+
+    /* sleep 1s to throttle callers in a loop on error, e.g. redis
+        is down. without this it floods /var/log and pins the CPU. */
+    if (ret == Select::ERROR)
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     return ret;
-
 }
 
 bool Select::isQueueEmpty()

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -188,11 +188,12 @@ int Select::select(Selectable **c, int timeout, bool interrupt_on_signal)
         ret = poll_descriptors(c, timeout, interrupt_on_signal);
     }
 
-    /* sleep 1s to throttle callers in a loop on error, e.g. redis
-        is down. without this it floods /var/log and pins the CPU. */
+    /* Sleep 1s to throttle callers in a loop on error (e.g., Redis is down).
+        Without this, it floods /var/log and pins the CPU. */
     if (ret == Select::ERROR)
     {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+         constexpr auto kErrorBackoff = std::chrono::seconds(1);
+         std::this_thread::sleep_for(kErrorBackoff);
     }
 
     return ret;

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -130,7 +130,16 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         }
         catch (const std::runtime_error& ex)
         {
-            SWSS_LOG_ERROR("readData error: %s", ex.what());
+            // Throttling by kErrorLogInterval avoids flooding /var/log and filling
+            // the partition from callers in a tight loop.
+            constexpr auto kErrorLogInterval = std::chrono::seconds(1);
+            static thread_local std::chrono::steady_clock::time_point lastErrorLog;
+            auto now = std::chrono::steady_clock::now();
+            if (now - lastErrorLog >= kErrorLogInterval)
+            {
+                SWSS_LOG_ERROR("readData error: %s", ex.what());
+                lastErrorLog = now;
+            }
             return Select::ERROR;
         }
         m_ready.insert(sel);
@@ -181,19 +190,17 @@ int Select::select(Selectable **c, int timeout, bool interrupt_on_signal)
     if (ret == Select::OBJECT || ret == Select::SIGNALINT || timeout == 0)
     {
         return ret;
-    }
-
-    if (ret == Select::TIMEOUT)
+    } else if (ret == Select::TIMEOUT)
     {
         ret = poll_descriptors(c, timeout, interrupt_on_signal);
-    }
-
-    /* Sleep 1s to throttle callers in a loop on error (e.g., Redis is down).
-        Without this, it floods /var/log and pins the CPU. */
-    if (ret == Select::ERROR)
+    } else if (ret == Select::ERROR)
     {
-         constexpr auto kErrorBackoff = std::chrono::seconds(1);
-         std::this_thread::sleep_for(kErrorBackoff);
+        // ERROR returns immediately, so a tight caller loop pins the CPU.
+        // Back off by the timeout capped at 1s; INFINITE (< 0) counts as the
+        // largest timeout, so it is capped to 1s.
+        constexpr int kMaxErrorBackoffMs = 1000;
+        int backoffMs = (timeout < 0 || timeout > kMaxErrorBackoffMs) ? kMaxErrorBackoffMs : timeout;
+        std::this_thread::sleep_for(std::chrono::milliseconds(backoffMs));
     }
 
     return ret;

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -129,6 +129,8 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         return Select::ERROR;
     }
 
+    bool readSuccess = false;
+
     for (int i = 0; i < ret; ++i)
     {
         int fd = events[i].data.fd;
@@ -136,7 +138,7 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         try
         {
             sel->readData();
-            s_consecutiveErrors = 0;
+            readSuccess = true;
         }
         catch (const std::runtime_error& ex)
         {
@@ -151,6 +153,11 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
             return Select::ERROR;
         }
         m_ready.insert(sel);
+    }
+
+    if (readSuccess)
+    {
+        s_consecutiveErrors = 0;
     }
 
     while (!m_ready.empty())

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -140,6 +140,8 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         }
         catch (const std::runtime_error& ex)
         {
+            // Only the first failing fd in the batch reaches here, and level-triggered epoll
+            // keeps its position stable, so a persistent outage saturates rather than resets.
             if (fd != s_lastFailedFd)
             {
                 s_lastFailedFd = fd;

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -17,6 +17,15 @@ using namespace std;
 
 namespace swss {
 
+namespace {
+
+constexpr unsigned int kMaxConsecutiveErrorLogs = 10;
+
+// Thread-local rather than a member so as not to break the ABI
+thread_local unsigned int s_consecutiveErrors = 0;
+
+}
+
 Select::Select()
 {
     m_epoll_fd = ::epoll_create1(0);
@@ -127,19 +136,18 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         try
         {
             sel->readData();
+            s_consecutiveErrors = 0;
         }
         catch (const std::runtime_error& ex)
         {
-            // Throttling by kErrorLogInterval avoids flooding /var/log and filling
-            // the partition from callers in a tight loop.
-            constexpr auto kErrorLogInterval = std::chrono::seconds(1);
-            static thread_local std::chrono::steady_clock::time_point lastErrorLog;
-            auto now = std::chrono::steady_clock::now();
-            if (now - lastErrorLog >= kErrorLogInterval)
+            if (s_consecutiveErrors < kMaxConsecutiveErrorLogs)
             {
-                SWSS_LOG_ERROR("readData error: %s", ex.what());
-                lastErrorLog = now;
+                s_consecutiveErrors++;
+                SWSS_LOG_ERROR("readData error: %s%s", ex.what(),
+                    s_consecutiveErrors == kMaxConsecutiveErrorLogs
+                        ? " (suppressing further logging until a successful read)" : "");
             }
+
             return Select::ERROR;
         }
         m_ready.insert(sel);
@@ -195,9 +203,8 @@ int Select::select(Selectable **c, int timeout, bool interrupt_on_signal)
         ret = poll_descriptors(c, timeout, interrupt_on_signal);
     } else if (ret == Select::ERROR)
     {
-        // ERROR returns immediately, so a tight caller loop pins the CPU.
-        // Back off by the timeout capped at 1s; INFINITE (< 0) counts as the
-        // largest timeout, so it is capped to 1s.
+        // ERROR returns immediately, so a tight caller loop pins the CPU. Back off
+        // by the timeout capped at 1s; INFINITE (< 0) counts as the largest timeout.
         constexpr int kMaxErrorBackoffMs = 1000;
         int backoffMs = (timeout < 0 || timeout > kMaxErrorBackoffMs) ? kMaxErrorBackoffMs : timeout;
         std::this_thread::sleep_for(std::chrono::milliseconds(backoffMs));

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -23,6 +23,7 @@ constexpr unsigned int kMaxConsecutiveErrorLogs = 10;
 
 // Thread-local rather than a member so as not to break the ABI
 thread_local unsigned int s_consecutiveErrors = 0;
+thread_local int s_lastFailedFd = -1;
 
 }
 
@@ -129,8 +130,6 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         return Select::ERROR;
     }
 
-    bool readSuccess = false;
-
     for (int i = 0; i < ret; ++i)
     {
         int fd = events[i].data.fd;
@@ -138,10 +137,15 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         try
         {
             sel->readData();
-            readSuccess = true;
         }
         catch (const std::runtime_error& ex)
         {
+            if (fd != s_lastFailedFd)
+            {
+                s_lastFailedFd = fd;
+                s_consecutiveErrors = 0;
+            }
+
             if (s_consecutiveErrors < kMaxConsecutiveErrorLogs)
             {
                 s_consecutiveErrors++;
@@ -155,10 +159,7 @@ int Select::poll_descriptors(Selectable **c, unsigned int timeout, bool interrup
         m_ready.insert(sel);
     }
 
-    if (readSuccess)
-    {
-        s_consecutiveErrors = 0;
-    }
+    s_consecutiveErrors = 0;
 
     while (!m_ready.empty())
     {

--- a/common/select.cpp
+++ b/common/select.cpp
@@ -2,8 +2,6 @@
 #include "common/logger.h"
 #include "common/select.h"
 #include <algorithm>
-#include <chrono>
-#include <thread>
 #include <stdio.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -204,23 +202,15 @@ int Select::select(Selectable **c, int timeout, bool interrupt_on_signal)
     /* check if we have some data */
     ret = poll_descriptors(c, 0);
 
-    /* return immediately if appropriate */
-    if (ret == Select::OBJECT || ret == Select::SIGNALINT || timeout == 0)
-    {
+    /* return if we have data, we have an error or desired timeout was 0 */
+    if (ret != Select::TIMEOUT || timeout == 0)
         return ret;
-    } else if (ret == Select::TIMEOUT)
-    {
-        ret = poll_descriptors(c, timeout, interrupt_on_signal);
-    } else if (ret == Select::ERROR)
-    {
-        // ERROR returns immediately, so a tight caller loop pins the CPU. Back off
-        // by the timeout capped at 1s; INFINITE (< 0) counts as the largest timeout.
-        constexpr int kMaxErrorBackoffMs = 1000;
-        int backoffMs = (timeout < 0 || timeout > kMaxErrorBackoffMs) ? kMaxErrorBackoffMs : timeout;
-        std::this_thread::sleep_for(std::chrono::milliseconds(backoffMs));
-    }
+
+    /* wait for data */
+    ret = poll_descriptors(c, timeout, interrupt_on_signal);
 
     return ret;
+
 }
 
 bool Select::isQueueEmpty()

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -9,6 +9,9 @@
 #include "common/netlink.h"
 #include "gtest/gtest.h"
 
+#include <chrono>
+#include <stdexcept>
+
 
 using namespace std;
 using namespace swss;
@@ -246,4 +249,52 @@ TEST(Priority, priority_select_6)
     EXPECT_EQ(ret, Select::OBJECT);
     // we gave fair scheduler. we've read different selectables on the second read
     EXPECT_NE(selectcs1, selectcs2);
+}
+
+namespace {
+
+// An always-readable Selectable whose readData() throws, mimicking a dead Redis
+// connection and driving Select::select() down its ERROR path. SelectableEvent
+// provides the eventfd plumbing; notify() makes it readable.
+class ThrowingSelectable : public SelectableEvent
+{
+public:
+    ThrowingSelectable() { notify(); }
+    uint64_t readData() override { throw runtime_error("Unable to read redis reply"); }
+};
+
+// select() a failing selectable with the given timeout; return elapsed ms and
+// the result via ret.
+long long selectFailing(int timeout, int &ret)
+{
+    ThrowingSelectable bad;
+    Select s;
+    s.addSelectable(&bad);
+
+    Selectable *sel = nullptr;
+    auto start = chrono::steady_clock::now();
+    ret = s.select(&sel, timeout);
+    return chrono::duration_cast<chrono::milliseconds>(
+        chrono::steady_clock::now() - start).count();
+}
+
+}
+
+// On ERROR, select() backs off ~1s so callers that loop on ERROR can't spin and
+// flood the log when Redis is down.
+TEST(Select, error_backoff)
+{
+    int ret;
+    long long elapsedMs = selectFailing(1000, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_GE(elapsedMs, 900);
+}
+
+// timeout == 0 stays non-blocking: return ERROR immediately, with no backoff.
+TEST(Select, nonblocking_error_no_backoff)
+{
+    int ret;
+    long long elapsedMs = selectFailing(0, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_LT(elapsedMs, 500);
 }

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -253,9 +253,7 @@ TEST(Priority, priority_select_6)
 
 namespace {
 
-// An always-readable Selectable whose readData() throws, mimicking a dead Redis
-// connection and driving Select::select() down its ERROR path. SelectableEvent
-// provides the eventfd plumbing; notify() makes it readable.
+// A selectable that always throws to test the ERROR path.
 class ThrowingSelectable : public SelectableEvent
 {
 public:
@@ -280,14 +278,26 @@ long long selectFailing(int timeout, int &ret)
 
 }
 
-// On ERROR, select() backs off ~1s so callers that loop on ERROR can't spin and
-// flood the log when Redis is down.
-TEST(Select, error_backoff)
+// On ERROR the backoff is the caller's timeout, capped at 1s. A sub-1s timeout
+// (300ms here) is below the cap, so the error surfaces after that exact timeout.
+TEST(Select, error_backoff_matches_timeout)
 {
     int ret;
-    long long elapsedMs = selectFailing(1000, ret);
+    long long elapsedMs = selectFailing(300, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_GE(elapsedMs, 250);
+    EXPECT_LT(elapsedMs, 900);
+}
+
+// A timeout above the 1s cap backs off by 1s, not the full timeout, bounding the
+// worst-case error-surfacing (and shutdown) latency during a redis outage.
+TEST(Select, error_backoff_capped_at_one_second)
+{
+    int ret;
+    long long elapsedMs = selectFailing(5000, ret);
     EXPECT_EQ(ret, Select::ERROR);
     EXPECT_GE(elapsedMs, 900);
+    EXPECT_LT(elapsedMs, 2000);
 }
 
 // timeout == 0 stays non-blocking: return ERROR immediately, with no backoff.
@@ -296,5 +306,17 @@ TEST(Select, nonblocking_error_no_backoff)
     int ret;
     long long elapsedMs = selectFailing(0, ret);
     EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_LT(elapsedMs, 500);
+    EXPECT_LT(elapsedMs, 200);
+}
+
+// INFINITE (timeout < 0) has no caller timeout to honor, so it is treated as the
+// largest timeout and backs off by the 1s cap -- enough to avoid pinning the CPU
+// (and pacing per-iteration caller logging) in a tight infinite-select loop.
+TEST(Select, infinite_error_capped_at_one_second)
+{
+    int ret;
+    long long elapsedMs = selectFailing(-1, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_GE(elapsedMs, 900);
+    EXPECT_LT(elapsedMs, 2000);
 }

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -376,3 +376,29 @@ TEST(Select, error_logging_rearms_after_successful_read)
     bad.notify();
     EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
 }
+
+// A different fd failing gets its own log budget instead of inheriting the
+// saturated counter from the fd that was already failing.
+TEST(Select, error_logging_resets_for_a_different_fd)
+{
+    FailingSelectable first;
+    FailingSelectable second;
+    Select s;
+    s.addSelectable(&first);
+    s.addSelectable(&second);
+
+    first.setFailing(false);
+    second.setFailing(false);
+    Selectable *sel = nullptr;
+    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+
+    first.setFailing(true);
+    first.notify();
+    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
+
+    first.setFailing(false);
+    second.setFailing(true);
+    first.notify();
+    second.notify();
+    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
+}

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -7,10 +7,11 @@
 #include "common/subscriberstatetable.h"
 #include "common/netmsg.h"
 #include "common/netlink.h"
+#include "common/logger.h"
 #include "gtest/gtest.h"
 
-#include <chrono>
 #include <stdexcept>
+#include <string>
 
 
 using namespace std;
@@ -253,70 +254,91 @@ TEST(Priority, priority_select_6)
 
 namespace {
 
-// A selectable that always throws to test the ERROR path.
-class ThrowingSelectable : public SelectableEvent
+// Mirrors kMaxConsecutiveErrorLogs in common/select.cpp.
+constexpr size_t kMaxErrorLogs = 10;
+
+// Throws on every read while failing, standing in for a selectable backed by an
+// unreachable redis.
+class FailingSelectable : public SelectableEvent
 {
 public:
-    ThrowingSelectable() { notify(); }
-    uint64_t readData() override { throw runtime_error("Unable to read redis reply"); }
+    FailingSelectable() { notify(); }
+
+    uint64_t readData() override
+    {
+        if (m_failing) throw runtime_error("Unable to read redis reply");
+        return SelectableEvent::readData();
+    }
+
+    void setFailing(bool failing) { m_failing = failing; }
+
+private:
+    bool m_failing = true;
 };
 
-// select() a failing selectable with the given timeout; return elapsed ms and
-// the result via ret.
-long long selectFailing(int timeout, int &ret)
+// Poll s n times, returning how many readData error lines were logged.
+size_t pollAndCountLogs(Select &s, int n)
 {
-    ThrowingSelectable bad;
+    Logger::swssOutputNotify("", "STDERR");
+    testing::internal::CaptureStderr();
+
+    for (int i = 0; i < n; i++)
+    {
+        Selectable *sel = nullptr;
+        s.select(&sel, 0);
+    }
+
+    string out = testing::internal::GetCapturedStderr();
+    Logger::swssOutputNotify("", "SYSLOG");
+
+    size_t logs = 0;
+    for (size_t p = out.find("readData error"); p != string::npos;
+         p = out.find("readData error", p + 1))
+    {
+        logs++;
+    }
+    return logs;
+}
+
+}
+
+// A tight caller loop against a permanently failing selectable logs a bounded
+// number of lines instead of filling /var/log.
+TEST(Select, error_logging_is_capped)
+{
+    FailingSelectable bad;
     Select s;
     s.addSelectable(&bad);
 
+    // Suppression state is per-thread, so start from a known-good state.
+    bad.setFailing(false);
     Selectable *sel = nullptr;
-    auto start = chrono::steady_clock::now();
-    ret = s.select(&sel, timeout);
-    return chrono::duration_cast<chrono::milliseconds>(
-        chrono::steady_clock::now() - start).count();
+    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+
+    bad.setFailing(true);
+    bad.notify();
+    EXPECT_EQ(pollAndCountLogs(s, 1000), kMaxErrorLogs);
 }
 
-}
-
-// On ERROR the backoff is the caller's timeout, capped at 1s. A sub-1s timeout
-// (300ms here) is below the cap, so the error surfaces after that exact timeout.
-TEST(Select, error_backoff_matches_timeout)
+// A successful read re-arms logging so a later outage is still reported.
+TEST(Select, error_logging_rearms_after_successful_read)
 {
-    int ret;
-    long long elapsedMs = selectFailing(300, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_GE(elapsedMs, 250);
-    EXPECT_LT(elapsedMs, 900);
-}
+    FailingSelectable bad;
+    Select s;
+    s.addSelectable(&bad);
 
-// A timeout above the 1s cap backs off by 1s, not the full timeout, bounding the
-// worst-case error-surfacing (and shutdown) latency during a redis outage.
-TEST(Select, error_backoff_capped_at_one_second)
-{
-    int ret;
-    long long elapsedMs = selectFailing(5000, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_GE(elapsedMs, 900);
-    EXPECT_LT(elapsedMs, 2000);
-}
+    bad.setFailing(false);
+    Selectable *sel = nullptr;
+    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
 
-// timeout == 0 stays non-blocking: return ERROR immediately, with no backoff.
-TEST(Select, nonblocking_error_no_backoff)
-{
-    int ret;
-    long long elapsedMs = selectFailing(0, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_LT(elapsedMs, 200);
-}
+    bad.setFailing(true);
+    bad.notify();
+    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
 
-// INFINITE (timeout < 0) has no caller timeout to honor, so it is treated as the
-// largest timeout and backs off by the 1s cap -- enough to avoid pinning the CPU
-// (and pacing per-iteration caller logging) in a tight infinite-select loop.
-TEST(Select, infinite_error_capped_at_one_second)
-{
-    int ret;
-    long long elapsedMs = selectFailing(-1, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_GE(elapsedMs, 900);
-    EXPECT_LT(elapsedMs, 2000);
+    bad.setFailing(false);
+    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+
+    bad.setFailing(true);
+    bad.notify();
+    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
 }

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -276,6 +276,21 @@ private:
     bool m_failing = true;
 };
 
+// Stays readable forever, standing in for a healthy selectable that keeps
+// producing data while another one is broken.
+class HealthySelectable : public SelectableEvent
+{
+public:
+    HealthySelectable() { notify(); }
+
+    uint64_t readData() override
+    {
+        uint64_t ret = SelectableEvent::readData();
+        notify();
+        return ret;
+    }
+};
+
 // Poll s n times, returning how many readData error lines were logged.
 size_t pollAndCountLogs(Select &s, int n)
 {
@@ -311,6 +326,25 @@ TEST(Select, error_logging_is_capped)
     s.addSelectable(&bad);
 
     // Suppression state is per-thread, so start from a known-good state.
+    bad.setFailing(false);
+    Selectable *sel = nullptr;
+    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+
+    bad.setFailing(true);
+    bad.notify();
+    EXPECT_EQ(pollAndCountLogs(s, 1000), kMaxErrorLogs);
+}
+
+// A healthy selectable read in the same poll must not re-arm logging for one that
+// keeps failing. It is added first so epoll tends to read it before the failing one.
+TEST(Select, error_logging_is_capped_alongside_a_healthy_selectable)
+{
+    HealthySelectable good;
+    FailingSelectable bad;
+    Select s;
+    s.addSelectable(&good);
+    s.addSelectable(&bad);
+
     bad.setFailing(false);
     Selectable *sel = nullptr;
     ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -10,6 +10,7 @@
 #include "common/logger.h"
 #include "gtest/gtest.h"
 
+#include <chrono>
 #include <stdexcept>
 #include <string>
 
@@ -291,114 +292,164 @@ public:
     }
 };
 
-// Poll s n times, returning how many readData error lines were logged.
-size_t pollAndCountLogs(Select &s, int n)
+class SelectErrorLogging : public ::testing::Test
 {
-    Logger::swssOutputNotify("", "STDERR");
-    testing::internal::CaptureStderr();
+protected:
+    Select s;
 
-    for (int i = 0; i < n; i++)
+    // Log suppression state is per-thread, so it outlives an individual test and
+    // only a successful read re-arms it. Tests read cleanly before asserting.
+    void readCleanly()
     {
         Selectable *sel = nullptr;
-        s.select(&sel, 0);
+        ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
     }
 
-    string out = testing::internal::GetCapturedStderr();
-    Logger::swssOutputNotify("", "SYSLOG");
-
-    size_t logs = 0;
-    for (size_t p = out.find("readData error"); p != string::npos;
-         p = out.find("readData error", p + 1))
+    // Poll n times, returning how many readData error lines were logged.
+    size_t pollAndCountLogs(int n)
     {
-        logs++;
+        Logger::swssOutputNotify("", "STDERR");
+        testing::internal::CaptureStderr();
+
+        for (int i = 0; i < n; i++)
+        {
+            Selectable *sel = nullptr;
+            s.select(&sel, 0);
+        }
+
+        string out = testing::internal::GetCapturedStderr();
+        Logger::swssOutputNotify("", "SYSLOG");
+
+        size_t logs = 0;
+        for (size_t p = out.find("readData error"); p != string::npos;
+             p = out.find("readData error", p + 1))
+        {
+            logs++;
+        }
+        return logs;
     }
-    return logs;
-}
+};
 
-}
-
-// A tight caller loop against a permanently failing selectable logs a bounded
-// number of lines instead of filling /var/log.
-TEST(Select, error_logging_is_capped)
+// select() a failing selectable with the given timeout; return elapsed ms and
+// the result via ret.
+long long selectFailing(int timeout, int &ret)
 {
     FailingSelectable bad;
     Select s;
     s.addSelectable(&bad);
 
-    // Suppression state is per-thread, so start from a known-good state.
-    bad.setFailing(false);
     Selectable *sel = nullptr;
-    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+    auto start = chrono::steady_clock::now();
+    ret = s.select(&sel, timeout);
+    return chrono::duration_cast<chrono::milliseconds>(
+        chrono::steady_clock::now() - start).count();
+}
 
-    bad.setFailing(true);
-    bad.notify();
-    EXPECT_EQ(pollAndCountLogs(s, 1000), kMaxErrorLogs);
 }
 
 // A healthy selectable read in the same poll must not re-arm logging for one that
 // keeps failing. It is added first so epoll tends to read it before the failing one.
-TEST(Select, error_logging_is_capped_alongside_a_healthy_selectable)
+TEST_F(SelectErrorLogging, capped_alongside_a_healthy_selectable)
 {
     HealthySelectable good;
     FailingSelectable bad;
-    Select s;
     s.addSelectable(&good);
     s.addSelectable(&bad);
 
     bad.setFailing(false);
-    Selectable *sel = nullptr;
-    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+    readCleanly();
 
     bad.setFailing(true);
     bad.notify();
-    EXPECT_EQ(pollAndCountLogs(s, 1000), kMaxErrorLogs);
+    EXPECT_EQ(pollAndCountLogs(1000), kMaxErrorLogs);
 }
 
-// A successful read re-arms logging so a later outage is still reported.
-TEST(Select, error_logging_rearms_after_successful_read)
+// A tight caller loop against a permanently failing selectable logs a bounded
+// number of lines instead of filling /var/log, and a later successful read re-arms
+// logging so a subsequent outage is still reported.
+TEST_F(SelectErrorLogging, capped_then_rearmed_by_a_successful_read)
 {
     FailingSelectable bad;
-    Select s;
     s.addSelectable(&bad);
 
     bad.setFailing(false);
-    Selectable *sel = nullptr;
-    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+    readCleanly();
 
     bad.setFailing(true);
     bad.notify();
-    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
+    EXPECT_EQ(pollAndCountLogs(100), kMaxErrorLogs);
 
     bad.setFailing(false);
-    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+    readCleanly();
 
     bad.setFailing(true);
     bad.notify();
-    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
+    EXPECT_EQ(pollAndCountLogs(100), kMaxErrorLogs);
 }
 
 // A different fd failing gets its own log budget instead of inheriting the
 // saturated counter from the fd that was already failing.
-TEST(Select, error_logging_resets_for_a_different_fd)
+TEST_F(SelectErrorLogging, resets_for_a_different_fd)
 {
     FailingSelectable first;
     FailingSelectable second;
-    Select s;
     s.addSelectable(&first);
     s.addSelectable(&second);
 
     first.setFailing(false);
     second.setFailing(false);
-    Selectable *sel = nullptr;
-    ASSERT_EQ(s.select(&sel, 0), Select::OBJECT);
+    readCleanly();
 
     first.setFailing(true);
     first.notify();
-    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
+    EXPECT_EQ(pollAndCountLogs(100), kMaxErrorLogs);
 
     first.setFailing(false);
     second.setFailing(true);
     first.notify();
     second.notify();
-    EXPECT_EQ(pollAndCountLogs(s, 100), kMaxErrorLogs);
+    EXPECT_EQ(pollAndCountLogs(100), kMaxErrorLogs);
+}
+
+// On ERROR the backoff is the caller's timeout, capped at 1s. A sub-1s timeout
+// (300ms here) is below the cap, so the error surfaces after that exact timeout.
+TEST(Select, error_backoff_matches_timeout)
+{
+    int ret;
+    long long elapsedMs = selectFailing(300, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_GE(elapsedMs, 250);
+    EXPECT_LT(elapsedMs, 900);
+}
+
+// A timeout above the 1s cap backs off by 1s, not the full timeout, bounding the
+// worst-case error-surfacing (and shutdown) latency during a redis outage.
+TEST(Select, error_backoff_capped_at_one_second)
+{
+    int ret;
+    long long elapsedMs = selectFailing(5000, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_GE(elapsedMs, 900);
+    EXPECT_LT(elapsedMs, 2000);
+}
+
+// timeout == 0 stays non-blocking: return ERROR immediately, with no backoff.
+TEST(Select, nonblocking_error_no_backoff)
+{
+    int ret;
+    long long elapsedMs = selectFailing(0, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_LT(elapsedMs, 200);
+}
+
+// INFINITE (timeout < 0) has no caller timeout to honor, so it is treated as the
+// largest timeout and backs off by the 1s cap -- enough to avoid pinning the CPU
+// (and pacing per-iteration caller logging) in a tight infinite-select loop.
+TEST(Select, infinite_error_capped_at_one_second)
+{
+    int ret;
+    long long elapsedMs = selectFailing(-1, ret);
+    EXPECT_EQ(ret, Select::ERROR);
+    EXPECT_GE(elapsedMs, 900);
+    EXPECT_LT(elapsedMs, 2000);
 }

--- a/tests/selectable_priority.cpp
+++ b/tests/selectable_priority.cpp
@@ -10,7 +10,6 @@
 #include "common/logger.h"
 #include "gtest/gtest.h"
 
-#include <chrono>
 #include <stdexcept>
 #include <string>
 
@@ -330,21 +329,6 @@ protected:
     }
 };
 
-// select() a failing selectable with the given timeout; return elapsed ms and
-// the result via ret.
-long long selectFailing(int timeout, int &ret)
-{
-    FailingSelectable bad;
-    Select s;
-    s.addSelectable(&bad);
-
-    Selectable *sel = nullptr;
-    auto start = chrono::steady_clock::now();
-    ret = s.select(&sel, timeout);
-    return chrono::duration_cast<chrono::milliseconds>(
-        chrono::steady_clock::now() - start).count();
-}
-
 }
 
 // A healthy selectable read in the same poll must not re-arm logging for one that
@@ -409,47 +393,4 @@ TEST_F(SelectErrorLogging, resets_for_a_different_fd)
     first.notify();
     second.notify();
     EXPECT_EQ(pollAndCountLogs(100), kMaxErrorLogs);
-}
-
-// On ERROR the backoff is the caller's timeout, capped at 1s. A sub-1s timeout
-// (300ms here) is below the cap, so the error surfaces after that exact timeout.
-TEST(Select, error_backoff_matches_timeout)
-{
-    int ret;
-    long long elapsedMs = selectFailing(300, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_GE(elapsedMs, 250);
-    EXPECT_LT(elapsedMs, 900);
-}
-
-// A timeout above the 1s cap backs off by 1s, not the full timeout, bounding the
-// worst-case error-surfacing (and shutdown) latency during a redis outage.
-TEST(Select, error_backoff_capped_at_one_second)
-{
-    int ret;
-    long long elapsedMs = selectFailing(5000, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_GE(elapsedMs, 900);
-    EXPECT_LT(elapsedMs, 2000);
-}
-
-// timeout == 0 stays non-blocking: return ERROR immediately, with no backoff.
-TEST(Select, nonblocking_error_no_backoff)
-{
-    int ret;
-    long long elapsedMs = selectFailing(0, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_LT(elapsedMs, 200);
-}
-
-// INFINITE (timeout < 0) has no caller timeout to honor, so it is treated as the
-// largest timeout and backs off by the 1s cap -- enough to avoid pinning the CPU
-// (and pacing per-iteration caller logging) in a tight infinite-select loop.
-TEST(Select, infinite_error_capped_at_one_second)
-{
-    int ret;
-    long long elapsedMs = selectFailing(-1, ret);
-    EXPECT_EQ(ret, Select::ERROR);
-    EXPECT_GE(elapsedMs, 900);
-    EXPECT_LT(elapsedMs, 2000);
 }


### PR DESCRIPTION
I have noticed two instances of filled /var/log on DUTs with many repeated lines:
```
2026 Jul 21 01:47:00.605758 ERR caclmgrd: :- poll_descriptors: readData error: Unable to read redis reply
2026 Jul 21 01:47:00.605776 ERR healthd: :- poll_descriptors: readData error: Unable to read redis reply
2026 Jul 21 01:47:00.605793 ERR featured: :- poll_descriptors: readData error: Unable to read redis reply
```
these repeat immediately, leading to /var/log partition being filled very quickly. It seems that the error case of `common/select.cpp` (e.g. if redis is down) returns immediately, leading to callers who call in loops spinning indefinitely and filling the log partition.

To fix this I propose the following change:

- The readData error log should be capped during consecutive failures, to avoid flooding /var/log/syslog and filling the partition.
- [REMOVED FROM THIS PR AHEAD OF FUTURE DISCUSSION] On the `Select::ERROR` path, we should enforce the timeout requested by the caller (often 1ms, 100ms, etc) up to a cap of 1 second, to avoid pinning the CPU in a hot loop.
