### PR TITLE
[ci]: Preserve dependency order across buildenv artifact install groups

### DIFF
--- a/ci/buildenv_setup/cascade.py
+++ b/ci/buildenv_setup/cascade.py
@@ -161,7 +161,13 @@ def collect_bundles(
     _seen: Optional[Set[str]] = None,
     _used_staged: Optional[Set[str]] = None,
 ) -> List[InstalledArtifact]:
-    """Fetch/stage every resolved upstream, glob files, and recurse (cascade)."""
+    """Fetch/stage every resolved upstream and return dependency-first artifacts.
+
+    An upstream bundle's nested ``upstream-artifacts.yaml`` describes that
+    artifact's dependencies. Recurse before appending the parent so the planner
+    can install providers before dependents, including across differing
+    ``install_env`` groups (for example common-libs -> VPP -> sairedis).
+    """
     required_staged = required_staged or set()
     seen = _seen if _seen is not None else set()
     # Thread the used-staged accumulator explicitly through the recursion so a
@@ -187,8 +193,6 @@ def collect_bundles(
                 art.deb_opts[f] = (rdeb.dpkg_args, rdeb.apt_fix_broken)
         for wpat in ru.wheels:
             art.wheel_files.extend(_glob_one(bundle_dir, wpat, "wheel", ru.name))
-        out.append(art)
-
         # Cascade: recurse into the bundle's own build-env/ if present.
         nested_up = os.path.join(bundle_dir, "build-env", "upstream-artifacts.yaml")
         if os.path.isfile(nested_up):
@@ -205,6 +209,7 @@ def collect_bundles(
                 "upstream %r bundle has no build-env/ to cascade into; "
                 "treating as leaf (set cascade_optional: true to silence)", ru.name
             )
+        out.append(art)
 
     # After the top-level pass, enforce required-staged overrides were all used.
     if _seen is None:

--- a/ci/buildenv_setup/planner.py
+++ b/ci/buildenv_setup/planner.py
@@ -155,30 +155,41 @@ def _pip_batches(pip_specs: List[Tuple[str, Tuple[str, ...]]]):
 
 
 def _deb_install_groups(artifacts) -> List[dict]:
-    """Group every artifact's DEBs by install_env signature into single dpkg -i
-    calls (see run() step 3 for rationale). Returns groups ordered so that the
-    empty-install_env group (the usual library providers such as libnl/libyang3/
-    libswsscommon) is installed before any special-install_env group (e.g. vpp).
-    Within a group, dpkg_args are unioned and apt_fix_broken is ORed."""
-    deb_groups: "OrderedDict[tuple, dict]" = OrderedDict()
+    """Batch dependency-first artifacts into ordered ``dpkg -i`` calls.
+
+    ``collect_bundles`` returns nested dependencies before their parents. Merge
+    only ADJACENT artifacts with the same ``install_env`` signature: dpkg can
+    then unpack/configure cross-artifact dependencies in one invocation without
+    moving a later dependent ahead of an intervening dependency that needs a
+    different environment (e.g. common-libs -> VPP -> sairedis).
+
+    Within a batch, dpkg_args are unioned and apt_fix_broken is ORed.
+    Artifacts containing only wheels do not split an otherwise-adjacent DEB
+    batch."""
+    deb_groups: List[dict] = []
+    current_sig = None
+    current = None
     for art in artifacts:
+        if not art.deb_files:
+            continue
         env_sig = tuple(sorted((art.install_env or {}).items()))
+        if current is None or env_sig != current_sig:
+            current_sig = env_sig
+            current = {
+                "files": [],
+                "args": [],
+                "fix": False,
+                "env": dict(art.install_env or {}),
+            }
+            deb_groups.append(current)
         for deb in art.deb_files:
             dpkg_args, fix = art.deb_opts.get(deb, ([], False))
-            g = deb_groups.get(env_sig)
-            if g is None:
-                g = {"files": [], "args": [], "fix": False, "env": dict(art.install_env or {})}
-                deb_groups[env_sig] = g
-            g["files"].append(deb)
+            current["files"].append(deb)
             for a in dpkg_args:
-                if a not in g["args"]:
-                    g["args"].append(a)
-            g["fix"] = g["fix"] or fix
-    # Empty-install_env group first (the usual library providers, installed before
-    # any special-env group like vpp); all other groups keep their insertion order
-    # (sorted() is stable), so inter-DEB dependencies across special-env groups are
-    # not reordered.
-    return [g for sig, g in sorted(deb_groups.items(), key=lambda kv: 0 if not kv[0] else 1)]
+                if a not in current["args"]:
+                    current["args"].append(a)
+            current["fix"] = current["fix"] or fix
+    return deb_groups
 
 
 def run(

--- a/ci/buildenv_setup/planner.py
+++ b/ci/buildenv_setup/planner.py
@@ -157,11 +157,13 @@ def _pip_batches(pip_specs: List[Tuple[str, Tuple[str, ...]]]):
 def _deb_install_groups(artifacts) -> List[dict]:
     """Batch dependency-first artifacts into ordered ``dpkg -i`` calls.
 
-    ``collect_bundles`` returns nested dependencies before their parents. Merge
-    only ADJACENT artifacts with the same ``install_env`` signature: dpkg can
-    then unpack/configure cross-artifact dependencies in one invocation without
-    moving a later dependent ahead of an intervening dependency that needs a
-    different environment (e.g. common-libs -> VPP -> sairedis).
+    The caller (normally ``collect_bundles``) must supply artifacts in
+    dependency-first order; this function preserves that order but does not
+    derive or validate dependencies itself. Merge only ADJACENT artifacts with
+    the same ``install_env`` signature: dpkg can then unpack/configure
+    cross-artifact dependencies in one invocation without moving a later
+    dependent ahead of an intervening dependency that needs a different
+    environment (e.g. common-libs -> VPP -> sairedis).
 
     Within a batch, dpkg_args are unioned and apt_fix_broken is ORed.
     Artifacts containing only wheels do not split an otherwise-adjacent DEB

--- a/ci/buildenv_setup/planner.py
+++ b/ci/buildenv_setup/planner.py
@@ -247,16 +247,13 @@ def run(
     # 2. apt install
     executor.apt_install(apt_names)
 
-    # 3. upstream DEBs (dpkg -i), before pip (F6). Group DEBs across ALL artifacts
-    #    by their install_env signature and install each group in ONE dpkg -i call,
-    #    so inter-DEB dependencies resolve regardless of declaration/filename order
-    #    — including cross-artifact deps, e.g. libswsscommon (sonic-swss-common)
-    #    depends on libnl-nf-3-200 + libyang3 (common-libs). dpkg unpacks the whole
-    #    set before configuring, so it orders configuration itself. Only a differing
-    #    install_env forces a separate call (e.g. vpp needs VPP_INSTALL_SKIP_SYSCTL=1
-    #    during its maintainer scripts); dpkg_args are unioned and apt_fix_broken is
-    #    ORed within a group. Empty-install_env groups (the usual library providers)
-    #    install first, before any special-env group.
+    # 3. upstream DEBs (dpkg -i), before pip (F6). collect_bundles returns
+    #    dependency-first artifacts. Batch only adjacent artifacts with the same
+    #    install_env so dpkg can resolve compatible cross-artifact dependencies
+    #    together (e.g. libswsscommon + common-libs) without moving a dependent
+    #    ahead of an intervening special-environment dependency (e.g.
+    #    common-libs -> VPP -> sairedis). dpkg_args are unioned and
+    #    apt_fix_broken is ORed within each ordered batch.
     for g in _deb_install_groups(artifacts):
         executor.dpkg_install(g["files"], dpkg_args=g["args"],
                               apt_fix_broken=g["fix"], env=g["env"])

--- a/ci/tests/test_cascade.py
+++ b/ci/tests/test_cascade.py
@@ -163,8 +163,7 @@ def test_cascade_recurses_into_nested_bundle(tmp_path):
     )])
     arts = collect_bundles(uf, BOOK_AMD, client=None, work_dir=str(tmp_path / "w"),
                            staged_dir=str(staged))
-    names = {a.name for a in arts}
-    assert names == {"sairedis", "sw-common"}   # cascade pulled in the nested upstream
+    assert [a.name for a in arts] == ["sw-common", "sairedis"]
 
 
 def test_required_staged_used_only_via_nested_bundle(tmp_path):
@@ -198,4 +197,4 @@ def test_required_staged_used_only_via_nested_bundle(tmp_path):
     # Requiring 'sw-common' (only reachable via the nested cascade) must NOT raise.
     arts = collect_bundles(uf, BOOK_AMD, client=None, work_dir=str(tmp_path / "w"),
                            staged_dir=str(staged), required_staged={"sw-common"})
-    assert {a.name for a in arts} == {"sairedis", "sw-common"}
+    assert [a.name for a in arts] == ["sw-common", "sairedis"]

--- a/ci/tests/test_planner.py
+++ b/ci/tests/test_planner.py
@@ -148,9 +148,9 @@ def test_deb_groups_merge_plain_upstreams_into_one_call():
     }
 
 
-def test_deb_groups_split_by_install_env_plain_first():
-    # vpp carries install_env (VPP_INSTALL_SKIP_SYSCTL) + apt_fix_broken, so it is
-    # a separate group installed AFTER the empty-install_env providers.
+def test_deb_groups_preserve_dependency_first_artifact_order():
+    # collect_bundles supplies dependency-first order. Different install_env
+    # signatures split calls without reordering them.
     plain = InstalledArtifact(
         name="common-libs", bundle_dir="/b/cl", deb_files=["/b/cl/libyang3.deb"],
     )
@@ -159,9 +159,9 @@ def test_deb_groups_split_by_install_env_plain_first():
         install_env={"VPP_INSTALL_SKIP_SYSCTL": "1"},
         deb_opts={"/b/vpp/vpp.deb": ([], True)},
     )
-    groups = _deb_install_groups([vpp, plain])   # declared vpp-first on purpose
+    groups = _deb_install_groups([plain, vpp])
     assert len(groups) == 2
-    assert groups[0]["files"] == ["/b/cl/libyang3.deb"]     # empty-env group first
+    assert groups[0]["files"] == ["/b/cl/libyang3.deb"]
     assert groups[0]["env"] == {}
     assert set(groups[1]["files"]) == {"/b/vpp/vpp.deb", "/b/vpp/libvppinfra.deb"}
     assert groups[1]["env"] == {"VPP_INSTALL_SKIP_SYSCTL": "1"}
@@ -183,15 +183,62 @@ def test_deb_groups_union_dpkg_args_within_group():
 
 
 def test_deb_groups_preserve_insertion_order_among_env_groups():
-    # Two DIFFERENT non-empty install_env groups: their relative order must follow
-    # insertion order (not be reordered by env-signature length), so inter-DEB deps
-    # across special-env groups aren't broken. Empty-env group still goes first.
+    # Every environment boundary preserves dependency-first insertion order,
+    # including an empty environment after special-environment dependencies.
     envA = InstalledArtifact(name="a", bundle_dir="/a", deb_files=["/a/a.deb"],
                              install_env={"A": "1"})
     envB = InstalledArtifact(name="b", bundle_dir="/b", deb_files=["/b/b.deb"],
                              install_env={"B": "1"})
     plain = InstalledArtifact(name="p", bundle_dir="/p", deb_files=["/p/p.deb"])
-    groups = _deb_install_groups([envA, envB, plain])   # declared A, B, plain
-    assert groups[0]["files"] == ["/p/p.deb"]           # empty-env first
-    assert groups[1]["env"] == {"A": "1"}               # then insertion order A ...
-    assert groups[2]["env"] == {"B": "1"}               # ... then B
+    groups = _deb_install_groups([envA, envB, plain])
+    assert groups[0]["env"] == {"A": "1"}
+    assert groups[1]["env"] == {"B": "1"}
+    assert groups[2]["files"] == ["/p/p.deb"]
+    assert groups[2]["env"] == {}
+
+
+def test_deb_groups_split_same_env_around_special_dependency():
+    # Regression: sairedis (empty env) depends on VPP (special env), while both
+    # depend on ordinary providers. Global grouping by env used to collapse the
+    # provider + sairedis DEBs into one early call, so apt repair removed
+    # libsaivs before VPP was installed. Preserve the dependency layers.
+    providers = InstalledArtifact(
+        name="common-libs", bundle_dir="/p", deb_files=["/p/libnl.deb"],
+    )
+    vpp = InstalledArtifact(
+        name="vpp", bundle_dir="/v", deb_files=["/v/vpp.deb"],
+        install_env={"VPP_INSTALL_SKIP_SYSCTL": "1"},
+    )
+    sairedis = InstalledArtifact(
+        name="sonic-sairedis", bundle_dir="/s", deb_files=["/s/libsaivs.deb"],
+    )
+
+    groups = _deb_install_groups([providers, vpp, sairedis])
+
+    assert [g["files"] for g in groups] == [
+        ["/p/libnl.deb"],
+        ["/v/vpp.deb"],
+        ["/s/libsaivs.deb"],
+    ]
+    assert [g["env"] for g in groups] == [
+        {},
+        {"VPP_INSTALL_SKIP_SYSCTL": "1"},
+        {},
+    ]
+
+
+def test_deb_groups_ignore_wheel_only_artifact_between_same_env_debs():
+    providers = InstalledArtifact(
+        name="provider", bundle_dir="/p", deb_files=["/p/provider.deb"],
+    )
+    wheels = InstalledArtifact(
+        name="wheels", bundle_dir="/w", wheel_files=["/w/package.whl"],
+    )
+    dependent = InstalledArtifact(
+        name="dependent", bundle_dir="/d", deb_files=["/d/dependent.deb"],
+    )
+
+    groups = _deb_install_groups([providers, wheels, dependent])
+
+    assert len(groups) == 1
+    assert groups[0]["files"] == ["/p/provider.deb", "/d/dependent.deb"]


### PR DESCRIPTION
## Summary

Fix `buildenv_setup` so cascading upstream dependencies are installed before
the artifacts that depend on them, including when an intervening dependency
requires a different `install_env`.

This is the root fix for sonic-swss PR #4821 / Azure build `1189333`, where the
flattened install plan put sairedis in the global empty-environment group before
VPP. `dpkg` left `libsaivs` unconfigured; `apt-get install -f` removed it; VPP
was installed only afterward; and the SWSS compile then failed because the SAI
headers were absent.

## Changes

- Traverse each bundle's nested `upstream-artifacts.yaml` before appending the
  parent artifact, producing a dependency-first artifact sequence.
- Replace global grouping by `install_env` with ordered batching:
  - merge only adjacent artifacts with the same environment;
  - preserve environment boundaries and dependency order;
  - allow wheel-only artifacts between compatible DEB providers/dependents
    without unnecessarily splitting the batch.
- Keep existing union behavior for `dpkg_args` and `apt_fix_broken` within each
  batch.

For the SWSS cascade, the resulting install plan is:

```text
common-libs + sonic-swss-common
VPP (VPP_INSTALL_SKIP_SYSCTL=1)
sonic-sairedis + sonic-dash-api
```

## Validation

- Targeted cascade/planner tests: **29 passed**.
- Full buildenv_setup suite: **118 passed**, **94% coverage**.
- Added regressions for:
  - dependency-first nested traversal;
  - required staged upstream reached only through nesting;
  - same-env provider/dependent separated by a special-env dependency;
  - preservation of environment insertion order;
  - wheel-only artifacts not splitting compatible DEB batches.
- Real end-to-end validation in `sonic-slave-bookworm:master-amd64` with the
  SWSS config **without** its temporary install-env workaround:
  - common-libs/swss-common installed first;
  - VPP installed second;
  - sairedis/dash installed third;
  - `vpp`, `libsaivs`, and `libsaivs-dev` all ended `install ok installed`.

After this merges, the temporary sairedis/VPP grouping workaround in
sonic-swss #4821 will be removed and that PR rerun against the shared fix.
