### PR TITLE
[ci]: Preserve Sonic DB config across Redis test restart

### DIFF
--- a/build-env/configure-redis-for-tests.sh
+++ b/build-env/configure-redis-for-tests.sh
@@ -11,8 +11,31 @@
 # sonic-swss and is harmless for sonic-sairedis (verified by sonic-sairedis CI).
 set -ex
 
-sudo sed -i  's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf
-sudo sed -ri 's/^# unixsocket/unixsocket/'                             /etc/redis/redis.conf
-sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/'              /etc/redis/redis.conf
-sudo sed -ri 's/redis-server.sock/redis.sock/'                        /etc/redis/redis.conf
+REDIS_CONFIG=${REDIS_CONFIG:-/etc/redis/redis.conf}
+SONIC_DB_CONFIG=${SONIC_DB_CONFIG:-/var/run/redis/sonic-db/database_config.json}
+
+# libswsscommon installs its DB configuration under /var/run/redis. Restarting
+# redis-server can recreate that runtime directory and remove the file, so keep
+# a temporary copy and restore it after the restart.
+sonic_db_config_backup=""
+cleanup()
+{
+    [ -z "$sonic_db_config_backup" ] || rm -f "$sonic_db_config_backup"
+}
+trap cleanup EXIT
+
+if sudo test -f "$SONIC_DB_CONFIG"; then
+    sonic_db_config_backup=$(mktemp)
+    sudo cp "$SONIC_DB_CONFIG" "$sonic_db_config_backup"
+fi
+
+sudo sed -i  's/notify-keyspace-events ""/notify-keyspace-events AKE/' "$REDIS_CONFIG"
+sudo sed -ri 's/^# unixsocket/unixsocket/'                             "$REDIS_CONFIG"
+sudo sed -ri 's/^unixsocketperm .../unixsocketperm 777/'              "$REDIS_CONFIG"
+sudo sed -ri 's/redis-server.sock/redis.sock/'                         "$REDIS_CONFIG"
 sudo service redis-server restart
+
+if [ -n "$sonic_db_config_backup" ]; then
+    sudo install -d -m 755 "$(dirname "$SONIC_DB_CONFIG")"
+    sudo install -m 644 "$sonic_db_config_backup" "$SONIC_DB_CONFIG"
+fi

--- a/ci/tests/test_post_install.py
+++ b/ci/tests/test_post_install.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -75,3 +77,45 @@ def test_select_upstream_entry_wins_at_test_scope():
                            scopes=["build", "test"], owner_build_env="/c/build-env")
     chosen = select([upstream, consumer], CTX_TEST)
     assert [e.owner_build_env for e in chosen] == ["/u/build-env"]
+
+
+def test_shared_redis_script_preserves_sonic_db_config_across_restart(tmp_path):
+    redis_config = tmp_path / "redis.conf"
+    redis_config.write_text(
+        'notify-keyspace-events ""\n'
+        '# unixsocket /var/run/redis/redis-server.sock\n'
+        'unixsocketperm 700\n'
+    )
+    sonic_db_config = tmp_path / "run" / "redis" / "sonic-db" / "database_config.json"
+    sonic_db_config.parent.mkdir(parents=True)
+    sonic_db_config.write_text('{"DATABASES": {}}\n')
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sudo = bindir / "sudo"
+    sudo.write_text("#!/bin/sh\nexec \"$@\"\n")
+    sudo.chmod(0o755)
+    service = bindir / "service"
+    service.write_text(
+        "#!/bin/sh\n"
+        'rm -rf "$(dirname "$SONIC_DB_CONFIG")"\n'
+    )
+    service.chmod(0o755)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bindir}:{env['PATH']}",
+        "REDIS_CONFIG": str(redis_config),
+        "SONIC_DB_CONFIG": str(sonic_db_config),
+    })
+    subprocess.run(
+        ["bash", str(repo_root / "build-env" / "configure-redis-for-tests.sh")],
+        env=env,
+        check=True,
+    )
+
+    assert sonic_db_config.read_text() == '{"DATABASES": {}}\n'
+    assert "notify-keyspace-events AKE" in redis_config.read_text()
+    assert "unixsocket /var/run/redis/redis.sock" in redis_config.read_text()
+    assert "unixsocketperm 777" in redis_config.read_text()


### PR DESCRIPTION
## Summary

Preserve libswsscommon's runtime `database_config.json` when the shared test
Redis hook restarts `redis-server`.

This fixes the remaining VS-test failure in sonic-swss #4821 / build `1196425`.
All Build/ARM/Trixie/Docker/ASAN stages passed, but normal VS tests failed before
test setup with:

```text
RuntimeError: Sonic database config file doesn't exist at
/var/run/redis/sonic-db/database_config.json
```

## Root cause

The Ubuntu `libswsscommon` DEB correctly installs the config directly at
`/var/run/redis/sonic-db/database_config.json`. `buildenv_setup` installs that
DEB, then runs the cascaded `configure-redis-for-tests.sh` post-install hook.
Restarting `redis-server` recreates its runtime directory and deletes the
package-installed `sonic-db` subdirectory/config. Host-side Python swsscommon
uses this fixed path even when connecting to the DVS container's Redis socket.

## Change

- If the Sonic DB runtime config exists, copy it to a temporary file before the
  Redis restart.
- Restore the directory/config with mode 0755/0644 after restart.
- Do nothing when libswsscommon is not installed and the file does not exist.
- Allow path overrides so the behavior can be tested without modifying system
  files.

## Validation

- Regression test uses fake `sudo`/`service`; the fake restart deletes the
  runtime directory and the script restores the exact config content.
- Targeted post-install tests: **8 passed**.
- Full buildenv_setup suite: **119 passed**, **94% coverage**.
- Real Ubuntu 22.04 test-host setup with a staged swss-common artifact:
  - `libswsscommon` and `python3-swsscommon` installed;
  - shared Redis hook backed up the config;
  - Redis restart removed/recreated the runtime directory;
  - hook restored `/var/run/redis/sonic-db/database_config.json`;
  - final existence/package checks passed.

After merge and a cascade-ready master artifact, sonic-swss #4821 will be
retriggered for the full VS suite.
