### PR TITLE
[common]: Validate interface name syntax

### DIFF
--- a/common/interface.h
+++ b/common/interface.h
@@ -9,9 +9,32 @@ namespace swss
 
 const size_t IFACE_NAME_MAX_LEN = IFNAMSIZ - 1;
 
-bool isInterfaceNameValid(const std::string &ifaceName)
+inline bool isInterfaceNameValid(const std::string &ifaceName)
 {
-    return !ifaceName.empty() && (ifaceName.length() < IFNAMSIZ);
+    if (ifaceName.empty() || ifaceName.length() >= IFNAMSIZ || ifaceName == "." || ifaceName == "..")
+    {
+        return false;
+    }
+
+    for (size_t index = 0; index < ifaceName.size(); ++index)
+    {
+        const unsigned char character = static_cast<unsigned char>(ifaceName[index]);
+        const bool isAlphaNumeric =
+            (character >= 'A' && character <= 'Z') ||
+            (character >= 'a' && character <= 'z') ||
+            (character >= '0' && character <= '9');
+        const bool isCommonCharacter =
+            isAlphaNumeric || character == '_' || character == '.';
+
+        if (isCommonCharacter || (index > 0 && character == '-'))
+        {
+            continue;
+        }
+
+        return false;
+    }
+
+    return true;
 }
 
 }

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -32,3 +32,13 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "interface_ut",
+    srcs = ["interface_ut.cpp"],
+    deps = [
+        "//:libswsscommon",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,6 +14,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/netdispatcher_ut.cpp         \
                       tests/ipaddress_ut.cpp            \
                       tests/ipprefix_ut.cpp             \
+                      tests/interface_ut.cpp            \
                       tests/macaddress_ut.cpp           \
                       tests/converter_ut.cpp            \
                       tests/exec_ut.cpp                 \

--- a/tests/interface_ut.cpp
+++ b/tests/interface_ut.cpp
@@ -1,0 +1,44 @@
+#include "gtest/gtest.h"
+
+#include "common/interface.h"
+
+TEST(InterfaceName, AcceptsCurrentCallerNames)
+{
+    EXPECT_TRUE(swss::isInterfaceNameValid("PortChannel0001"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("Vrf-RED"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("vtep1"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("Ethernet0.100"));
+}
+
+TEST(InterfaceName, AcceptsSharedSyntax)
+{
+    EXPECT_TRUE(swss::isInterfaceNameValid("Ethernet0"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("PortChannel1"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("Eth0.100"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("Ethernet-BP0"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("1Ethernet"));
+    EXPECT_TRUE(swss::isInterfaceNameValid("_eth0"));
+    EXPECT_TRUE(swss::isInterfaceNameValid(".eth0"));
+    EXPECT_TRUE(swss::isInterfaceNameValid(std::string(swss::IFACE_NAME_MAX_LEN, 'a')));
+}
+
+TEST(InterfaceName, RejectsUnsupportedSyntax)
+{
+    EXPECT_FALSE(swss::isInterfaceNameValid(""));
+    EXPECT_FALSE(swss::isInterfaceNameValid("."));
+    EXPECT_FALSE(swss::isInterfaceNameValid(".."));
+    EXPECT_FALSE(swss::isInterfaceNameValid("-Ethernet0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Port Channel"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet0/1"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet0:1"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet0@1"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet;0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet$0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet`0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet|0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet&0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet\\0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet\n0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid("Ethernet\t0"));
+    EXPECT_FALSE(swss::isInterfaceNameValid(std::string(IFNAMSIZ, 'a')));
+}

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -6,3 +6,42 @@ def test_is_interface_name_valid():
 
     validInterfaceName = "OkInterfaceName"
     assert swsscommon.isInterfaceNameValid(validInterfaceName)
+
+
+def test_is_interface_name_valid_syntax():
+    for name in (
+        "Ethernet0",
+        "PortChannel1",
+        "PortChannel0001",
+        "Eth0.100",
+        "Ethernet0.100",
+        "Ethernet-BP0",
+        "Vrf-RED",
+        "vtep1",
+        "1Ethernet",
+        "_eth0",
+        ".eth0",
+        "a" * 15,
+    ):
+        assert swsscommon.isInterfaceNameValid(name)
+
+    for name in (
+        "",
+        ".",
+        "..",
+        "-Ethernet0",
+        "Port Channel",
+        "Ethernet0/1",
+        "Ethernet0:1",
+        "Ethernet0@1",
+        "Ethernet;0",
+        "Ethernet$0",
+        "Ethernet`0",
+        "Ethernet|0",
+        "Ethernet&0",
+        "Ethernet\\0",
+        "Ethernet\n0",
+        "Ethernet\t0",
+        "a" * 16,
+    ):
+        assert not swsscommon.isInterfaceNameValid(name)


### PR DESCRIPTION
## What I did

Strengthened the existing `swss::isInterfaceNameValid()` helper to validate the shared interface-name syntax:

- Length is 1 through 15 bytes.
- The first character is an ASCII letter, digit, underscore, or period.
- Remaining characters may additionally contain hyphens.
- The complete names `.` and `..` are rejected.

Added focused C++ and Python binding coverage.

## Why I did it

This provides one shared validator through `sonic-swss-common` for C++, Python, and other supported bindings.

Existing callers in `sonic-utilities` were audited, including PortChannel, VRF, VXLAN, and subinterface validation. Their supported interface names continue to pass, and the existing function name and signature remain unchanged.

This supersedes:

- sonic-net/sonic-buildimage#29189
- sonic-net/sonic-swss#4844

## Testing

Built the Bookworm Debian packages using the repository’s canonical build environment. All three focused C++ tests and both Python binding tests passed. Coverage includes current caller name categories, accepted and rejected syntax, and 15/16-byte length boundaries.