### PR TITLE
[common]: Add shared VRF name validation

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -100,6 +100,7 @@ common_libswsscommon_la_SOURCES = \
     common/asyncdbupdater.cpp        \
     common/redis_table_waiter.cpp    \
     common/interface.h               \
+    common/vrf.h                     \
     common/c-api/util.cpp                  \
     common/c-api/dbconnector.cpp           \
     common/c-api/configdbconnector.cpp     \

--- a/common/vrf.h
+++ b/common/vrf.h
@@ -1,0 +1,42 @@
+#ifndef __VRF__
+#define __VRF__
+
+#include <net/if.h>
+#include <string>
+
+namespace swss
+{
+
+const size_t VRF_NAME_MAX_LEN = IFNAMSIZ - 1;
+
+inline bool isVrfNameValid(const std::string &vrfName)
+{
+    if (vrfName.empty() || vrfName.length() >= IFNAMSIZ || vrfName == "." || vrfName == "..")
+    {
+        return false;
+    }
+
+    for (size_t index = 0; index < vrfName.size(); ++index)
+    {
+        const unsigned char character = static_cast<unsigned char>(vrfName[index]);
+        const bool isAlphaNumeric =
+            (character >= 'A' && character <= 'Z') ||
+            (character >= 'a' && character <= 'z') ||
+            (character >= '0' && character <= '9');
+        const bool isCommonCharacter =
+            isAlphaNumeric || character == '_' || character == '.';
+
+        if (isCommonCharacter || (index > 0 && character == '-'))
+        {
+            continue;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+}
+
+#endif

--- a/pyext/swsscommon.i
+++ b/pyext/swsscommon.i
@@ -60,6 +60,7 @@
 #include <memory>
 #include <functional>
 #include "interface.h"
+#include "vrf.h"
 %}
 
 %include <std_string.i>
@@ -295,6 +296,7 @@ T castSelectableObj(swss::Selectable *temp)
 %include "zmqclient.h"
 %include "zmqconsumerstatetable.h"
 %include "interface.h"
+%include "vrf.h"
 
 %extend swss::DBConnector {
     %template(hgetall) hgetall<std::map<std::string, std::string>>;

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -32,3 +32,13 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "vrf_ut",
+    srcs = ["vrf_ut.cpp"],
+    deps = [
+        "//:libswsscommon",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,6 +14,7 @@ tests_tests_SOURCES = tests/redis_ut.cpp                \
                       tests/netdispatcher_ut.cpp         \
                       tests/ipaddress_ut.cpp            \
                       tests/ipprefix_ut.cpp             \
+                      tests/vrf_ut.cpp                  \
                       tests/macaddress_ut.cpp           \
                       tests/converter_ut.cpp            \
                       tests/exec_ut.cpp                 \

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -1,0 +1,26 @@
+from swsscommon import swsscommon
+
+
+def test_is_vrf_name_valid_syntax():
+    for name in (
+        "default",
+        "mgmt",
+        "vrfRED",
+        "Vrf-RED_1",
+        "Vrf.RED",
+        "a" * 15,
+    ):
+        assert swsscommon.isVrfNameValid(name)
+
+    for name in (
+        "",
+        ".",
+        "..",
+        "-VrfRED",
+        "Vrf RED",
+        "Vrf/RED",
+        "Vrf:RED",
+        "Vrf|RED",
+        "a" * 16,
+    ):
+        assert not swsscommon.isVrfNameValid(name)

--- a/tests/vrf_ut.cpp
+++ b/tests/vrf_ut.cpp
@@ -1,0 +1,26 @@
+#include "gtest/gtest.h"
+
+#include "common/vrf.h"
+
+TEST(VrfName, AcceptsCurrentNames)
+{
+    EXPECT_TRUE(swss::isVrfNameValid("default"));
+    EXPECT_TRUE(swss::isVrfNameValid("mgmt"));
+    EXPECT_TRUE(swss::isVrfNameValid("vrfRED"));
+    EXPECT_TRUE(swss::isVrfNameValid("Vrf-RED_1"));
+    EXPECT_TRUE(swss::isVrfNameValid("Vrf.RED"));
+    EXPECT_TRUE(swss::isVrfNameValid(std::string(swss::VRF_NAME_MAX_LEN, 'a')));
+}
+
+TEST(VrfName, RejectsUnsupportedSyntax)
+{
+    EXPECT_FALSE(swss::isVrfNameValid(""));
+    EXPECT_FALSE(swss::isVrfNameValid("."));
+    EXPECT_FALSE(swss::isVrfNameValid(".."));
+    EXPECT_FALSE(swss::isVrfNameValid("-VrfRED"));
+    EXPECT_FALSE(swss::isVrfNameValid("Vrf RED"));
+    EXPECT_FALSE(swss::isVrfNameValid("Vrf/RED"));
+    EXPECT_FALSE(swss::isVrfNameValid("Vrf:RED"));
+    EXPECT_FALSE(swss::isVrfNameValid("Vrf|RED"));
+    EXPECT_FALSE(swss::isVrfNameValid(std::string(IFNAMSIZ, 'a')));
+}


### PR DESCRIPTION
## What I did

Added a shared `swss::isVrfNameValid()` helper with C++ and Python bindings.
The validator applies the Linux interface-name constraints used by SONiC VRFs:

- Length is 1 through 15 bytes.
- The first character is an ASCII letter, digit, underscore, or period.
- Remaining characters may additionally contain hyphens.
- The complete names `.` and `..` are rejected.

Added focused C++ and Python coverage for current VRF names, accepted syntax,
rejected syntax, and the 15/16-byte boundary.

## Why I did it

This provides one reusable VRF-name validator through `sonic-swss-common`
instead of requiring each consumer to maintain its own pattern. Existing forms
including `default`, `mgmt`, `vrfRED`, and `Vrf-RED_1` remain accepted.

The first consumer is sonic-net/sonic-buildimage#29228.

## Testing

- Canonical Bookworm Debian package build completed successfully.
- Focused C++ tests: `2 passed`.
- Python binding test: `1 passed`.
